### PR TITLE
Guaranty a device deletion event is published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@
 lazy val `ota-device-registry` =
   project
     .in(file("."))
-    .enablePlugins(AutomateHeaderPlugin, GitVersioning, BuildInfoPlugin, DockerPlugin, JavaAppPackaging)
+    .enablePlugins(GitVersioning, BuildInfoPlugin, DockerPlugin, JavaAppPackaging)
     .settings(settings)
     .settings(
       resolvers += "Sonatype Nexus Repository Manager" at "http://nexus.advancedtelematic.com:8081/content/repositories/releases"

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/Boot.scala
@@ -26,6 +26,7 @@ import com.advancedtelematic.libats.slick.monitoring.{DatabaseMetrics, DbHealthR
 import com.advancedtelematic.metrics.{AkkaHttpRequestMetrics, InfluxdbMetricsReporterSupport}
 import com.advancedtelematic.metrics.prometheus.PrometheusMetricsSupport
 import com.advancedtelematic.ota.deviceregistry.daemon.{
+  DeleteDeviceHandler,
   DeviceEventListener,
   DeviceSeenListener,
   DeviceUpdateStatusListener
@@ -109,6 +110,7 @@ object Boot
   deviceSeenListener ! Subscribe
 
   new DeviceEventListener(system.settings.config, db, metricRegistry).start()
+  new DeleteDeviceHandler(system.settings.config, db, metricRegistry).start()
 
   val host = config.getString("server.host")
   val port = config.getInt("server.port")

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -29,7 +29,7 @@ import com.advancedtelematic.ota.deviceregistry.db.{
   GroupMemberRepository,
   InstalledPackages
 }
-import com.advancedtelematic.ota.deviceregistry.messages.{DeviceCreated, DeviceDeleted, DeviceEventMessage}
+import com.advancedtelematic.ota.deviceregistry.messages.{DeleteDeviceRequest, DeviceCreated, DeviceEventMessage}
 import com.advancedtelematic.ota.deviceregistry.DevicesResource.EventPayload
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Regex
@@ -110,15 +110,10 @@ class DevicesResource(
   }
 
   def deleteDevice(ns: Namespace, uuid: Uuid): Route = {
-    val f = db
-      .run(DeviceRepository.delete(ns, uuid))
-      .andThen {
-        case scala.util.Success(_) =>
-          messageBus.publish(
-            DeviceDeleted(ns, uuid, Instant.now())
-          )
-      }
-    onSuccess(f) { complete(StatusCodes.NoContent) }
+    val f = messageBus.publish(
+      DeleteDeviceRequest(ns, uuid, Instant.now())
+    )
+    onSuccess(f) { complete(StatusCodes.Accepted) }
   }
 
   def fetchDevice(uuid: Uuid): Route =

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeleteDeviceHandler.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeleteDeviceHandler.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 HERE Technologies
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.advancedtelematic.ota.deviceregistry.daemon
+
+import akka.Done
+import akka.actor.ActorSystem
+import com.advancedtelematic.libats.messaging.MessageListener
+import com.advancedtelematic.libats.messaging.daemon.MessageBusListenerActor.Subscribe
+import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
+import com.advancedtelematic.ota.deviceregistry.messages.DeleteDeviceRequest
+import com.codahale.metrics.MetricRegistry
+import com.typesafe.config.Config
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DeleteDeviceHandler(config: Config, db: Database, metrics: MetricRegistry)(
+    implicit val ec: ExecutionContext,
+    system: ActorSystem
+) {
+
+  def start(): Unit = {
+    val listener = system.actorOf(MessageListener.props[DeleteDeviceRequest](system.settings.config, handle, metrics),
+                                  "delete-device-handler")
+    listener ! Subscribe
+  }
+
+  private[this] def handle(message: DeleteDeviceRequest): Future[Done] =
+    db.run(DeviceRepository.delete(message.namespace, message.uuid).map(_ => Done))
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeleteDeviceRequest.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeleteDeviceRequest.scala
@@ -15,10 +15,10 @@ import com.advancedtelematic.libats.messaging_datatype.MessageLike
 import com.advancedtelematic.ota.deviceregistry.data.Uuid
 import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceId, DeviceName, DeviceType}
 
-final case class DeviceDeleted(namespace: Namespace, uuid: Uuid, timestamp: Instant = Instant.now())
+final case class DeleteDeviceRequest(namespace: Namespace, uuid: Uuid, timestamp: Instant = Instant.now())
 
-object DeviceDeleted {
+object DeleteDeviceRequest {
   import cats.syntax.show._
   import com.advancedtelematic.libats.codecs.CirceCodecs._
-  implicit val MessageLikeInstance = MessageLike[DeviceDeleted](_.uuid.show)
+  implicit val MessageLikeInstance = MessageLike[DeleteDeviceRequest](_.uuid.show)
 }


### PR DESCRIPTION
- Web API endpoint publishes an event to kafka
- background job subscribes to events and deletes the device