### PR TITLE
Move ECU info to dev-reg and add an endpoint to fetch it.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val `ota-device-registry` =
       libraryDependencies += "org.tpolecat" %% "atto-core" % "0.6.2"
     )
     .settings(libraryDependencies ++= library.libAts)
+    .settings(libraryDependencies ++= library.libTuf)
     .settings(dependencyOverrides += "com.typesafe.akka" %% "akka-stream-kafka" % "0.18")
 
 // *****************************************************************************
@@ -31,12 +32,13 @@ lazy val `ota-device-registry` =
 lazy val library =
   new {
     object Version {
+      val akkaHttp = "10.0.10"
+      val circe = "0.9.1"
+      val libAts = "0.2.1-2-g962e326"
+      val libTuf = "0.6.0-18-g5b8b259"
+      val mariaDb = "1.4.4"
       val scalaCheck = "1.13.5"
       val scalaTest  = "3.0.4"
-      val libAts     = "0.2.1-2-g962e326"
-      val akkaHttp = "10.0.10"
-      val mariaDb = "1.4.4"
-      val circe = "0.9.1"
     }
     val scalaCheck = "org.scalacheck" %% "scalacheck" % Version.scalaCheck
     val scalaTest  = "org.scalatest"  %% "scalatest"  % Version.scalaTest
@@ -52,6 +54,7 @@ lazy val library =
       "libats-http-tracing",
       "libats-logging"
     ).map("com.advancedtelematic" %% _ % Version.libAts)
+    val libTuf = Seq("libtuf", "libtuf-server").map("com.advancedtelematic" %% _ % Version.libTuf)
     val akkaHttpTestKit = "com.typesafe.akka" %% "akka-http-testkit" % Version.akkaHttp
     val mariaDb = "org.mariadb.jdbc" % "mariadb-java-client" % Version.mariaDb
     val circeTesting = "io.circe" %% "circe-testing" % Version.circe

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -39,6 +39,14 @@ auditor = {
   migrate = ${?AUDITOR_MIGRATE}
 }
 
+director = {
+  host = "localhost"
+  host = ${?DIRECTOR_HOST}
+  port = 8084
+  port = ${?DIRECTOR_PORT}
+  uri = "http://"${director.host}":"${director.port}
+}
+
 main {
   defaultNs = "default"
   defaultNs = ${?DEFAULT_NAMESPACE}

--- a/src/main/resources/db/migration/V30__create_ecu_table.sql
+++ b/src/main/resources/db/migration/V30__create_ecu_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE Ecu (
+  device_uuid CHAR(36)      NOT NULL COLLATE utf8_bin,
+  ecu_id      VARCHAR(64)   NOT NULL,
+  ecu_type    VARCHAR(200)  NULL,
+  `primary`   BOOL          NOT NULL,
+  public_key  VARCHAR(4096) NOT NULL,
+
+  PRIMARY KEY (device_uuid, ecu_id),
+  CONSTRAINT `fk_ecu_device` FOREIGN KEY (device_uuid) REFERENCES Device(uuid)
+);

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -146,6 +146,11 @@ class DevicesResource(
   def countDynamicGroupCandidates(ns: Namespace, expression: GroupExpression): Route =
     complete(db.run(DeviceRepository.countDevicesForExpression(ns, expression)))
 
+  def getEcusForDevice(ns: Namespace, deviceId: DeviceId): Route =
+    parameters(('offset.as[Long].?, 'limit.as[Long].?)) { (offset, limit) =>
+      complete(db.run(EcuRepository.listEcusForDevice(deviceId, offset, limit)))
+    }
+
   def getGroupsForDevice(ns: Namespace, uuid: DeviceId): Route =
     parameters(('offset.as[Long].?, 'limit.as[Long].?)) { (offset, limit) =>
       complete(db.run(GroupMemberRepository.listGroupsForDevice(ns, uuid, offset, limit)))
@@ -238,6 +243,9 @@ class DevicesResource(
       } ~
       deviceNamespaceAuthorizer { uuid =>
         scope.get {
+          path("ecus") {
+            getEcusForDevice(ns.namespace, uuid)
+          } ~
           path("groups") {
             getGroupsForDevice(ns.namespace, uuid)
           } ~

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResource.scala
@@ -27,7 +27,7 @@ import com.advancedtelematic.ota.deviceregistry.messages.{DeviceCreated, DeviceP
 import slick.jdbc.MySQLProfile.api._
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Codecs._
-import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DataType.CreateDevice
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -52,7 +52,7 @@ class PublicCredentialsResource(
       FetchPublicCredentials(uuid, creds.typeCredentials, new String(creds.credentials))
     })
 
-  def createDeviceWithPublicCredentials(ns: Namespace, devT: DeviceT): Route = {
+  def createDeviceWithPublicCredentials(ns: Namespace, devT: CreateDevice): Route = {
     val act = devT.credentials match {
       case Some(credentials) => {
         val cType = devT.credentialsType.getOrElse(CredentialsType.PEM)
@@ -82,7 +82,7 @@ class PublicCredentialsResource(
     (pathPrefix("devices") & authNamespace) { ns =>
       val scope = Scopes.devices(ns)
       pathEnd {
-        (scope.put & entity(as[DeviceT])) { devT =>
+        (scope.put & entity(as[CreateDevice])) { devT =>
           createDeviceWithPublicCredentials(ns.namespace, devT)
         }
       } ~

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/client/DirectorClient.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/client/DirectorClient.scala
@@ -1,0 +1,51 @@
+package com.advancedtelematic.ota.deviceregistry.client
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model._
+import akka.stream.Materializer
+import cats.syntax.show._
+import com.advancedtelematic.libats.codecs.CirceCodecs.{refinedDecoder, refinedEncoder}
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.libats.http.Errors.RemoteServiceError
+import com.advancedtelematic.libats.http.HttpOps.HttpRequestOps
+import com.advancedtelematic.libats.http.ServiceHttpClient
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libtuf.data.TufCodecs._
+import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, TufKey}
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.Decoder
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+
+final case class EcuInfo(id: EcuIdentifier, hardwareId: HardwareIdentifier, primary: Boolean)
+
+trait DirectorClient {
+  def getEcuInfo(ns: Namespace, deviceId: DeviceId): Future[Seq[EcuInfo]]
+  def getPublicKey(ns: Namespace, deviceId: DeviceId, ecuIds: EcuIdentifier): Future[TufKey]
+}
+
+class DirectorHttpClient(uri: Uri, httpClient: HttpRequest => Future[HttpResponse])
+                       (implicit ec: ExecutionContext, system: ActorSystem, mat: Materializer) extends ServiceHttpClient(httpClient) with DirectorClient {
+
+  private val _log = LoggerFactory.getLogger(this.getClass)
+  private val pathPrefix = uri.path / "api" / "v1" / "admin" / "devices"
+  implicit val ecuDecoder: Decoder[EcuInfo] = io.circe.generic.semiauto.deriveDecoder
+
+  override def getEcuInfo(ns: Namespace, deviceId: DeviceId): Future[Seq[EcuInfo]] = {
+    val path = pathPrefix / deviceId.show
+    val req = HttpRequest(HttpMethods.GET, uri.withPath(path)).withNs(ns)
+    execHttp[Seq[EcuInfo]](req)().recover {
+      case e: RemoteServiceError =>
+        _log.warn(s"Unable to fetch ECU info for ns $ns and device $deviceId.", e)
+        Seq.empty
+    }
+  }
+
+  override def getPublicKey(ns: Namespace, deviceId: DeviceId, ecuId: EcuIdentifier): Future[TufKey] = {
+    val path = pathPrefix / deviceId.show / "ecus" / ecuId.value / "public_key"
+    val req = HttpRequest(HttpMethods.GET, uri.withPath(path)).withNs(ns)
+    execHttp[TufKey](req)()
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
@@ -18,13 +18,14 @@ import com.advancedtelematic.ota.deviceregistry.db.PublicCredentialsRepository.D
 import com.advancedtelematic.ota.deviceregistry.db.SystemInfoRepository.SystemInfo
 
 object Errors {
-  import akka.http.scaladsl.model.StatusCodes
+  import akka.http.scaladsl.model.StatusCodes._
 
   object Codes {
     val MissingDevice                      = ErrorCode("missing_device")
     val ConflictingDevice                  = ErrorCode("conflicting_device")
     val SystemInfoAlreadyExists            = ErrorCode("system_info_already_exists")
     val MissingGroupInfo                   = ErrorCode("missing_group_info")
+    val MissingPrimaryEcu                  = ErrorCode("missing_primary_ecu")
     val GroupAlreadyExists                 = ErrorCode("group_already_exists")
     val MemberAlreadyExists                = ErrorCode("device_already_a_group_member")
     val RequestNeedsCredentials            = ErrorCode("request_needs_credentials")
@@ -34,16 +35,16 @@ object Errors {
     val InvalidGroupExpression             = ErrorCode("invalid_group_expression")
   }
 
-  def InvalidGroupExpression(err: String) = RawError(Codes.InvalidGroupExpression, StatusCodes.BadRequest, s"Invalid group expression: '$err'")
+  def InvalidGroupExpression(err: String) = RawError(Codes.InvalidGroupExpression, BadRequest, s"Invalid group expression: '$err'")
 
   def InvalidGroupExpressionForGroupType(groupType: GroupType, expression: Option[GroupExpression]) =
     RawError(Codes.InvalidGroupExpressionForGroupType,
-             StatusCodes.BadRequest,
+             BadRequest,
              s"Invalid group expression $expression for group type $groupType")
 
-  val MissingDevice = RawError(Codes.MissingDevice, StatusCodes.NotFound, "device doesn't exist")
+  val MissingDevice = RawError(Codes.MissingDevice, NotFound, "device doesn't exist")
   val ConflictingDevice =
-    RawError(Codes.ConflictingDevice, StatusCodes.Conflict, "deviceId or deviceName is already in use")
+    RawError(Codes.ConflictingDevice, Conflict, "deviceId or deviceName is already in use")
   val MissingSystemInfo     = MissingEntity[SystemInfo]
   val ConflictingSystemInfo = EntityAlreadyExists[SystemInfo]
 
@@ -53,13 +54,15 @@ object Errors {
 
   val MissingDevicePublicCredentials = MissingEntity[DevicePublicCredentials]
   val RequestNeedsCredentials =
-    RawError(Codes.RequestNeedsCredentials, StatusCodes.BadRequest, "request should contain credentials")
+    RawError(Codes.RequestNeedsCredentials, BadRequest, "request should contain credentials")
 
   val CannotAddDeviceToDynamicGroup =
-    RawError(Codes.CannotAddDeviceToDynamicGroup, StatusCodes.BadRequest, "cannot add device to dynamic group")
+    RawError(Codes.CannotAddDeviceToDynamicGroup, BadRequest, "cannot add device to dynamic group")
 
   val CannotRemoveDeviceFromDynamicGroup =
     RawError(Codes.CannotRemoveDeviceFromDynamicGroup,
-             StatusCodes.BadRequest,
+             BadRequest,
              "cannot remove device from dynamic group")
+
+  val MissingPrimaryEcu = RawError(Codes.MissingPrimaryEcu, BadRequest, "Missing primary ecu id in the request.")
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
@@ -1,19 +1,29 @@
 package com.advancedtelematic.ota.deviceregistry.data
 
 import io.circe.{Decoder, Encoder}
-import com.advancedtelematic.libats.codecs.CirceCodecs.{refinedDecoder, refinedEncoder}
-import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStat, UpdateDevice}
+import com.advancedtelematic.libats.codecs.CirceCodecs._
+import com.advancedtelematic.libtuf.data.TufCodecs._
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{CreateDevice, CreateEcu, Ecu, InstallationStat, UpdateDevice}
+import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 
 object Codecs {
-  private implicit val deviceIdEncoder = Encoder.encodeString.contramap[Device.DeviceOemId](_.underlying)
-  private implicit val deviceIdDecoder = Decoder.decodeString.map(Device.DeviceOemId.apply)
 
-  implicit val deviceTEncoder = io.circe.generic.semiauto.deriveEncoder[DeviceT]
-  implicit val deviceTDecoder = io.circe.generic.semiauto.deriveDecoder[DeviceT]
+  implicit val deviceIdEncoder = Encoder.encodeString.contramap[DeviceOemId](_.underlying)
+  implicit val deviceIdDecoder = Decoder.decodeString.map(DeviceOemId.apply)
+
+  implicit val ecuEncoder: Encoder[Ecu] = io.circe.generic.semiauto.deriveEncoder[Ecu]
+  implicit val ecuDecoder: Decoder[Ecu] = io.circe.generic.semiauto.deriveDecoder[Ecu]
 
   implicit val updateDeviceEncoder = io.circe.generic.semiauto.deriveEncoder[UpdateDevice]
   implicit val updateDeviceDecoder = io.circe.generic.semiauto.deriveDecoder[UpdateDevice]
 
   implicit val installationStatEncoder = io.circe.generic.semiauto.deriveEncoder[InstallationStat]
   implicit val installationStatDecoder = io.circe.generic.semiauto.deriveDecoder[InstallationStat]
+
+  implicit val createEcuEncoder = io.circe.generic.semiauto.deriveEncoder[CreateEcu]
+  implicit val createEcuDecoder = io.circe.generic.semiauto.deriveDecoder[CreateEcu]
+
+  implicit val createDeviceEncoder = io.circe.generic.semiauto.deriveEncoder[CreateDevice]
+  implicit val createDeviceDecoder = io.circe.generic.semiauto.deriveDecoder[CreateDevice]
+
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -3,9 +3,11 @@ package com.advancedtelematic.ota.deviceregistry.data
 import java.time.Instant
 
 import cats.Show
+import cats.data.NonEmptyList
 import com.advancedtelematic.libats.data.DataType.CorrelationId
 import com.advancedtelematic.libats.data.EcuIdentifier
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, Event}
+import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, TufKey}
 import com.advancedtelematic.ota.deviceregistry.data.CredentialsType.CredentialsType
 import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType.IndexedEventType
 import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceName, DeviceOemId, DeviceType}
@@ -16,6 +18,9 @@ import eu.timepit.refined.string.Regex
 import io.circe.Json
 
 object DataType {
+
+  final case class Ecu(deviceUuid: DeviceId, ecuId: EcuIdentifier, ecuType: HardwareIdentifier, primary: Boolean, tufKey: TufKey)
+
   case class IndexedEvent(device: DeviceId, eventID: String, eventType: IndexedEventType, correlationId: Option[CorrelationId])
 
   case class InstallationStat(resultCode: String, total: Int, success: Boolean)
@@ -31,13 +36,6 @@ object DataType {
     case object Device extends InstallationStatsLevel
     case object Ecu extends InstallationStatsLevel
   }
-
-  final case class DeviceT(uuid: Option[DeviceId] = None,
-                           deviceName: DeviceName,
-                           deviceId: DeviceOemId,
-                           deviceType: DeviceType = DeviceType.Other,
-                           credentials: Option[String] = None,
-                           credentialsType: Option[CredentialsType] = None)
 
   final case class UpdateDevice(deviceName: DeviceName)
 
@@ -55,4 +53,14 @@ object DataType {
       require(regex.isEmpty, "Invalid parameters: regex must be empty when searching by deviceId.")
     }
   }
+
+  final case class CreateEcu(ecuId: EcuIdentifier, ecuType: HardwareIdentifier, clientKey: TufKey)
+  final case class CreateDevice(uuid: Option[DeviceId] = None,
+                                deviceName: DeviceName,
+                                deviceId: DeviceOemId,
+                                primaryEcu: EcuIdentifier,
+                                ecus: NonEmptyList[CreateEcu],
+                                deviceType: DeviceType = DeviceType.Other,
+                                credentials: Option[String] = None,
+                                credentialsType: Option[CredentialsType] = None)
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EcuRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EcuRepository.scala
@@ -1,0 +1,48 @@
+package com.advancedtelematic.ota.deviceregistry.db
+
+import java.time.Instant
+
+import com.advancedtelematic.libats.data.{EcuIdentifier, PaginationResult}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libats.slick.codecs.SlickRefined._
+import com.advancedtelematic.libats.slick.db.SlickAnyVal._
+import com.advancedtelematic.libats.slick.db.SlickExtensions.javaInstantMapping
+import com.advancedtelematic.libats.slick.db.SlickPagination._
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
+import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, TufKey}
+import com.advancedtelematic.libtuf_server.data.TufSlickMappings._
+import com.advancedtelematic.ota.deviceregistry.data.DataType.Ecu
+import com.advancedtelematic.ota.deviceregistry.db.DbOps.PaginationResultOps
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.ExecutionContext
+
+object EcuRepository {
+
+  class EcuTable(tag: Tag) extends Table[Ecu](tag, "Ecu") {
+    def deviceUuid = column[DeviceId]("device_uuid")
+    def ecuId      = column[EcuIdentifier]("ecu_id")
+    def ecuType    = column[HardwareIdentifier]("ecu_type")
+    def primary    = column[Boolean]("primary")
+    def publicKey  = column[TufKey]("public_key")
+
+    def createdAt = column[Instant]("created_at")
+
+    def pk = primaryKey("ecu_pk", (deviceUuid, ecuId))
+
+    override def * = (deviceUuid, ecuId, ecuType, primary, publicKey) <> ((Ecu.apply _).tupled, Ecu.unapply)
+  }
+
+  protected[db] val ecus = TableQuery[EcuTable]
+
+  def listEcusForDevice(deviceUuid: DeviceId, offset: Option[Long], limit: Option[Long])
+                       (implicit ec: ExecutionContext): DBIO[PaginationResult[Ecu]] = {
+    ecus
+      .filter(_.deviceUuid === deviceUuid)
+      .paginateResult(offset.orDefaultOffset, limit.orDefaultLimit)
+  }
+
+  def delete(deviceUuid: DeviceId): DBIO[Int] = ecus.filter(_.deviceUuid === deviceUuid).delete
+
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateEcuInfoFromDirector.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateEcuInfoFromDirector.scala
@@ -1,0 +1,44 @@
+package com.advancedtelematic.ota.deviceregistry.db
+
+import akka.Done
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.ota.deviceregistry.client.DirectorClient
+import com.advancedtelematic.ota.deviceregistry.data.DataType.Ecu
+import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository.devices
+import com.advancedtelematic.ota.deviceregistry.db.SlickMappings.namespaceColumnType
+import org.slf4j.LoggerFactory
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class MigrateEcuInfoFromDirector(director: DirectorClient)(implicit db: Database,
+                                                           ec: ExecutionContext,
+                                                           mat: Materializer) {
+
+  private val _log = LoggerFactory.getLogger(this.getClass)
+
+  def saveEcu(ecu: Ecu): Future[EcuIdentifier] = {
+    _log.info(s"Migrating ECU from director: $ecu.")
+    db.run(EcuRepository.ecus.insertOrUpdate(ecu).map(_ => ecu.ecuId))
+  }
+
+  def run: Future[Done] = {
+    val source = db.stream(devices.map(d => (d.namespace, d.uuid)).result)
+    Source
+      .fromPublisher(source)
+      .mapAsyncUnordered(1) { case (ns, did) => director.getEcuInfo(ns, did).map(_.map((ns, did, _))) }
+      .mapConcat(_.toList)
+      .mapAsyncUnordered(4) { case (ns, did, ecuInfo) =>
+        for {
+          pubKey <- director.getPublicKey(ns, did, ecuInfo.id)
+          ecuId <- saveEcu(Ecu(did, ecuInfo.id, ecuInfo.hardwareId, ecuInfo.primary, pubKey))
+        } yield ecuId
+      }
+      .runWith {
+        Sink.foreach(ecuId => _log.info(s"Migrated ECU $ecuId"))
+      }
+  }
+}

--- a/src/main/scala/db/migration/R__EcuInformationMigration.scala
+++ b/src/main/scala/db/migration/R__EcuInformationMigration.scala
@@ -1,0 +1,25 @@
+package db.migration
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.libats.http.ServiceHttpClientSupport
+import com.advancedtelematic.libats.slick.db.AppMigration
+import com.advancedtelematic.ota.deviceregistry.client.DirectorHttpClient
+import com.advancedtelematic.ota.deviceregistry.db.MigrateEcuInfoFromDirector
+import com.typesafe.config.ConfigFactory
+import slick.jdbc.MySQLProfile.api.Database
+
+import scala.concurrent.Future
+
+class R__EcuInformationMigration extends AppMigration with ServiceHttpClientSupport {
+
+  implicit val system: ActorSystem = ActorSystem(this.getClass.getSimpleName)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  import system.dispatcher
+
+  private val directorUri = ConfigFactory.load().getString("director.uri")
+  private val director = new DirectorHttpClient(directorUri, defaultHttpClient)
+
+  override def migrate(implicit db: Database): Future[Unit] =
+    new MigrateEcuInfoFromDirector(director).run.map(_ => ())
+}

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -112,6 +112,9 @@ trait DeviceRequests { self: ResourceSpec =>
   def deleteDevice(uuid: DeviceId)(implicit ec: ExecutionContext): HttpRequest =
     Delete(Resource.uri(api, uuid.show))
 
+  def fetchEcuInfo(uuid: DeviceId): HttpRequest =
+    Get(Resource.uri(api, uuid.show, "ecus"))
+
   def fetchSystemInfo(uuid: DeviceId): HttpRequest =
     Get(Resource.uri(api, uuid.show, "system_info"))
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -20,7 +20,7 @@ import com.advancedtelematic.libats.http.HttpOps.HttpRequestOps
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsLevel.InstallationStatsLevel
-import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, UpdateDevice}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{CreateDevice, UpdateDevice}
 import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.data.PackageId
@@ -91,16 +91,19 @@ trait DeviceRequests { self: ResourceSpec =>
   def updateDevice(uuid: DeviceId, newName: DeviceName)(implicit ec: ExecutionContext): HttpRequest =
     Put(Resource.uri(api, uuid.show), UpdateDevice(newName))
 
-  def createDevice(device: DeviceT)(implicit ec: ExecutionContext): HttpRequest =
+  def createDevice(device: Json)(implicit ec: ExecutionContext): HttpRequest =
     Post(Resource.uri(api), device)
 
-  def createDeviceOk(device: DeviceT)(implicit ec: ExecutionContext): DeviceId =
+  def createDevice(device: CreateDevice)(implicit ec: ExecutionContext): HttpRequest =
+    Post(Resource.uri(api), device)
+
+  def createDeviceOk(device: CreateDevice)(implicit ec: ExecutionContext): DeviceId =
     createDevice(device) ~> route ~> check {
       status shouldBe Created
       responseAs[DeviceId]
   }
 
-  def createDeviceInNamespaceOk(device: DeviceT, ns: Namespace)(implicit ec: ExecutionContext): DeviceId =
+  def createDeviceInNamespaceOk(device: CreateDevice, ns: Namespace)(implicit ec: ExecutionContext): DeviceId =
     Post(Resource.uri(api), device).withNs(ns) ~> route ~> check {
       status shouldBe Created
       responseAs[DeviceId]

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
@@ -799,6 +799,18 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
     }
   }
 
+  property("creates a device with ECU information") {
+    val newDevice = genCreateDevice.generate
+    val deviceUuid = createDeviceOk(newDevice)
+
+    fetchEcuInfo(deviceUuid) ~> route ~> check {
+      status shouldBe OK
+      val result = responseAs[PaginationResult[Ecu]].values
+      val expected = newDevice.ecus.map(e => (e.ecuId, e.ecuType, e.clientKey, e.ecuId == newDevice.primaryEcu)).toList
+      result.map(e => (e.ecuId, e.ecuType, e.tufKey, e.primary)) shouldBe expected
+    }
+  }
+
   property("fails to create a device if no ECUs are given") {
     val newDevice = parse("""{
                          "deviceName" : "A device without ECUs",

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
@@ -36,7 +36,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("device gets added to dynamic group") {
-    val deviceT    = genDeviceT.sample.get
+    val deviceT    = genCreateDevice.sample.get
     val deviceUuid = createDeviceOk(deviceT)
     val groupId    = createDynamicGroupOk(deviceT.deviceId.toValidExp)
 
@@ -66,7 +66,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("manually adding a device to dynamic group fails") {
-    val deviceT    = genDeviceT.sample.get
+    val deviceT    = genCreateDevice.sample.get
     val deviceUuid = createDeviceOk(deviceT)
     val groupId    = createDynamicGroupOk(deviceT.deviceId.toValidExp)
 
@@ -76,7 +76,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("counts devices for dynamic group") {
-    val deviceT = genDeviceT.sample.get
+    val deviceT = genCreateDevice.sample.get
     val _       = createDeviceOk(deviceT)
     val groupId    = createDynamicGroupOk(deviceT.deviceId.toValidExp)
 
@@ -87,7 +87,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("removing a device from a dynamic group fails") {
-    val deviceT    = genDeviceT.sample.get
+    val deviceT    = genCreateDevice.sample.get
     val deviceUuid = createDeviceOk(deviceT)
     val groupId    = createDynamicGroupOk(deviceT.deviceId.toValidExp)
 
@@ -97,7 +97,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("deleting a device causes it to be removed from dynamic group") {
-    val deviceT    = genDeviceT.sample.get
+    val deviceT    = genCreateDevice.sample.get
     val deviceUuid = createDeviceOk(deviceT)
     val groupId    = createDynamicGroupOk(deviceT.deviceId.toValidExp)
     listDevicesInGroup(groupId) ~> route ~> check {
@@ -116,7 +116,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device returns the correct dynamic groups") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("12347890800808"))
+    val deviceT = genCreateDevice.sample.get.copy(deviceName = Refined.unsafeApply("12347890800808"))
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
@@ -135,7 +135,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device using two 'contains' returns the correct dynamic groups") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("ABCDEFGHIJ"))
+    val deviceT = genCreateDevice.sample.get.copy(deviceName = Refined.unsafeApply("ABCDEFGHIJ"))
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
@@ -153,7 +153,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device returns the correct groups (dynamic and static)") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("ABCDE"))
+    val deviceT = genCreateDevice.sample.get.copy(deviceName = Refined.unsafeApply("ABCDE"))
     val deviceUuid = createDeviceOk(deviceT)
 
     // Add the device to a static group

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/EventJournalSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/EventJournalSpec.scala
@@ -21,7 +21,7 @@ import com.advancedtelematic.libats.messaging_datatype.MessageCodecs._
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceEventMessage
 import com.advancedtelematic.ota.deviceregistry.EventJournalSpec.EventPayload
 import com.advancedtelematic.ota.deviceregistry.daemon.{DeleteDeviceHandler, DeviceEventListener}
-import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DataType.CreateDevice
 import com.advancedtelematic.ota.deviceregistry.db.EventJournal
 import com.advancedtelematic.ota.deviceregistry.messages.DeleteDeviceRequest
 import io.circe.generic.semiauto._
@@ -91,7 +91,7 @@ class EventJournalSpec extends ResourcePropSpec with ScalaFutures with Eventuall
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   property("events can be recorded in journal and retrieved") {
-    forAll { (device: DeviceT, events: List[EventPayload]) =>
+    forAll { (device: CreateDevice, events: List[EventPayload]) =>
       val deviceUuid = createDeviceOk(device)
 
       events
@@ -113,7 +113,7 @@ class EventJournalSpec extends ResourcePropSpec with ScalaFutures with Eventuall
   }
 
   property("indexes an event by type") {
-    val deviceUuid = createDeviceOk(genDeviceT.generate)
+    val deviceUuid = createDeviceOk(genCreateDevice.generate)
     val (event0, correlationId0) = installCompleteEventGen.generate
     val event1 = EventGen.retryUntil(_.eventType.id != "InstallationComplete").generate
 
@@ -135,7 +135,7 @@ class EventJournalSpec extends ResourcePropSpec with ScalaFutures with Eventuall
   }
 
   property("DELETE device archives its indexed events") {
-    val uuid = createDeviceOk(genDeviceT.generate)
+    val uuid = createDeviceOk(genCreateDevice.generate)
     val (e, _) = installCompleteEventGen.generate
     val event = Event(uuid, e.id.toString, e.eventType, e.deviceTime, Instant.now, e.event)
     val deviceEventMessage = DeviceEventMessage(defaultNs, event)

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupsResourceSpec.scala
@@ -93,7 +93,7 @@ class GroupsResourceSpec extends FunSuite with ResourceSpec {
     val deviceNumber = 50
     val groupId      = createStaticGroupOk()
 
-    val deviceTs             = genConflictFreeDeviceTs(deviceNumber).sample.get
+    val deviceTs             = genConflictFreeCreateDevices(deviceNumber).sample.get
     val deviceIds = deviceTs.map(createDeviceOk)
 
     deviceIds.foreach(deviceId => addDeviceToGroupOk(groupId, deviceId))
@@ -110,7 +110,7 @@ class GroupsResourceSpec extends FunSuite with ResourceSpec {
     val deviceNumber = 50
     val groupId      = createStaticGroupOk()
 
-    val deviceTs             = genConflictFreeDeviceTs(deviceNumber).sample.get
+    val deviceTs             = genConflictFreeCreateDevices(deviceNumber).sample.get
     val deviceIds = deviceTs.map(createDeviceOk)
 
     deviceIds.foreach(deviceId => addDeviceToGroupOk(groupId, deviceId))
@@ -170,7 +170,7 @@ class GroupsResourceSpec extends FunSuite with ResourceSpec {
 
   test("adds devices to groups") {
     val groupId    = createStaticGroupOk()
-    val deviceUuid = createDeviceOk(genDeviceT.sample.get)
+    val deviceUuid = createDeviceOk(genCreateDevice.sample.get)
 
     addDeviceToGroup(groupId, deviceUuid) ~> route ~> check {
       status shouldBe OK
@@ -194,7 +194,7 @@ class GroupsResourceSpec extends FunSuite with ResourceSpec {
   }
 
   test("removes devices from a group") {
-    val deviceId  = createDeviceOk(genDeviceT.sample.get)
+    val deviceId  = createDeviceOk(genCreateDevice.sample.get)
     val groupId   = createStaticGroupOk()
 
     addDeviceToGroup(groupId, deviceId) ~> route ~> check {

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/InstallationReportSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/InstallationReportSpec.scala
@@ -62,7 +62,7 @@ class InstallationReportSpec extends ResourcePropSpec with ScalaFutures with Eve
   }
 
   property("should save the whole message as a blob and get back the history for a device") {
-    val deviceId       = createDeviceOk(genDeviceT.generate)
+    val deviceId       = createDeviceOk(genCreateDevice.generate)
     val correlationIds = Gen.listOfN(50, genCorrelationId).generate
     val deviceReports  = correlationIds.map(cid => genDeviceInstallationReport(cid, "0", deviceId)).map(_.generate)
 
@@ -88,7 +88,7 @@ class InstallationReportSpec extends ResourcePropSpec with ScalaFutures with Eve
     val resultCodes = Seq("0", "1", "2", "2", "3", "3", "3")
     val resultDescriptions = Map("0" -> "Description-0", "1" -> "Description-1", "2" -> "Description-2", "3" -> "Description-3")
 
-    val createDevices = genConflictFreeDeviceTs(resultCodes.length).generate
+    val createDevices = genConflictFreeCreateDevices(resultCodes.length).generate
     val deviceUuids = createDevices.map(createDeviceOk)
     val rows = deviceUuids.zip(createDevices).zip(resultCodes).map {
       case ((uuid, cd), rc) => (uuid, cd.deviceId, rc, resultDescriptions(rc))
@@ -112,7 +112,7 @@ class InstallationReportSpec extends ResourcePropSpec with ScalaFutures with Eve
     val resultCodes = Seq("0", "1", "2", "2")
     val resultDescriptions = Map("0" -> "Description-0", "1" -> "Description-1", "2" -> "Description-2")
 
-    val createDevices = genConflictFreeDeviceTs(resultCodes.length).generate
+    val createDevices = genConflictFreeCreateDevices(resultCodes.length).generate
     val deviceUuids = createDevices.map(createDeviceOk)
     val rows = deviceUuids.zip(createDevices).zip(resultCodes).map {
       case ((uuid, cd), rc) => (uuid, cd.deviceId, rc, resultDescriptions(rc))

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsRequests.scala
@@ -18,7 +18,7 @@ import eu.timepit.refined.api.Refined
 import scala.concurrent.ExecutionContext
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Codecs._
-import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DataType.CreateDevice
 
 trait PublicCredentialsRequests { self: ResourceSpec =>
   import StatusCodes._
@@ -43,18 +43,18 @@ trait PublicCredentialsRequests { self: ResourceSpec =>
       base64Decoder.decode(resp.credentials)
     }
 
-  def createDeviceWithCredentials(devT: DeviceT)(implicit ec: ExecutionContext): HttpRequest =
-    Put(Resource.uri(credentialsApi), devT)
+  def createDeviceWithCredentials(payload: CreateDevice)(implicit ec: ExecutionContext): HttpRequest =
+    Put(Resource.uri(credentialsApi), payload)
 
   def updatePublicCredentials(device: DeviceOemId, creds: Array[Byte], cType: Option[CredentialsType])
                              (implicit ec: ExecutionContext): HttpRequest = {
-    val devT = DeviceT(
-      None,
-      Refined.unsafeApply(device.underlying),
-      device,
+    val payload = genCreateDevice.sample.get.copy(
+      deviceName = Refined.unsafeApply(device.underlying),
+      deviceId = device,
       credentials = Some(base64Encoder.encodeToString(creds)),
       credentialsType = cType)
-    createDeviceWithCredentials(devT)
+
+    createDeviceWithCredentials(payload)
   }
 
   def updatePublicCredentialsOk(device: DeviceOemId, creds: Array[Byte], cType: Option[CredentialsType] = None)

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResourceSpec.scala
@@ -14,7 +14,7 @@ import com.advancedtelematic.ota.deviceregistry.PublicCredentialsResource.FetchP
 import io.circe.generic.auto._
 import org.scalacheck.{Arbitrary, Gen}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DataType.CreateDevice
 
 class PublicCredentialsResourceSpec extends ResourcePropSpec {
   import Device._
@@ -42,7 +42,7 @@ class PublicCredentialsResourceSpec extends ResourcePropSpec {
   }
 
   property("PUT uses existing uuid if device exists") {
-    forAll { (devId: DeviceOemId, mdevT: DeviceT, creds: Array[Byte]) =>
+    forAll { (devId: DeviceOemId, mdevT: CreateDevice, creds: Array[Byte]) =>
       val devT = mdevT.copy(deviceId = devId)
       val uuid: DeviceId = createDeviceOk(devT)
       uuid shouldBe updatePublicCredentialsOk(devId, creds)
@@ -68,7 +68,7 @@ class PublicCredentialsResourceSpec extends ResourcePropSpec {
   }
 
   property("Type of credentials is set correctly") {
-    forAll { (deviceId: DeviceOemId, mdevT: DeviceT, creds: String, cType: CredentialsType.CredentialsType) =>
+    forAll { (deviceId: DeviceOemId, mdevT: CreateDevice, creds: String, cType: CredentialsType.CredentialsType) =>
       val devT = mdevT.copy(deviceId = deviceId, credentials = Some(creds), credentialsType = Some(cType))
       val uuid: DeviceId = createDeviceWithCredentials(devT) ~> route ~> check {
         status shouldBe OK

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/SystemInfoResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/SystemInfoResourceSpec.scala
@@ -12,7 +12,7 @@ import com.advancedtelematic.ota.deviceregistry.db.SystemInfoRepository.removeId
 import io.circe.Json
 import org.scalacheck.Shrink
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DataType.CreateDevice
 
 class SystemInfoResourceSpec extends ResourcePropSpec {
   import akka.http.scaladsl.model.StatusCodes._
@@ -35,7 +35,7 @@ class SystemInfoResourceSpec extends ResourcePropSpec {
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   property("GET /system_info/network returns empty strings if network info was not reported") {
-    forAll { (device: DeviceT, json: Option[Json]) =>
+    forAll { (device: CreateDevice, json: Option[Json]) =>
       val uuid = createDeviceOk(device)
 
       json.foreach { sysinfo =>
@@ -55,7 +55,7 @@ class SystemInfoResourceSpec extends ResourcePropSpec {
   }
 
   property("GET /system_info return empty if device have not set system_info") {
-    forAll { device: DeviceT =>
+    forAll { device: CreateDevice =>
       val uuid = createDeviceOk(device)
 
       fetchSystemInfo(uuid) ~> route ~> check {
@@ -68,7 +68,7 @@ class SystemInfoResourceSpec extends ResourcePropSpec {
   }
 
   property("GET system_info after POST should return what was posted.") {
-    forAll { (device: DeviceT, json0: Json) =>
+    forAll { (device: CreateDevice, json0: Json) =>
       val uuid  = createDeviceOk(device)
       val json1: Json = removeIdNrs(json0)
 
@@ -85,7 +85,7 @@ class SystemInfoResourceSpec extends ResourcePropSpec {
   }
 
   property("GET system_info after PUT should return what was updated.") {
-    forAll { (device: DeviceT, json1: Json, json2: Json) =>
+    forAll { (device: CreateDevice, json1: Json, json2: Json) =>
       val uuid = createDeviceOk(device)
 
       createSystemInfo(uuid, json1) ~> route ~> check {
@@ -105,7 +105,7 @@ class SystemInfoResourceSpec extends ResourcePropSpec {
   }
 
   property("PUT system_info if not previously created should create it.") {
-    forAll { (device: DeviceT, json: Json) =>
+    forAll { (device: CreateDevice, json: Json) =>
       val uuid = createDeviceOk(device)
 
       updateSystemInfo(uuid, json) ~> route ~> check {
@@ -136,7 +136,7 @@ class SystemInfoResourceSpec extends ResourcePropSpec {
                              case (_, v)               => getField(field)(v)
                          })
 
-    forAll { (device: DeviceT, json0: Json) =>
+    forAll { (device: CreateDevice, json0: Json) =>
       val uuid = createDeviceOk(device)
       val json       = removeIdNrs(json0)
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeviceInstallationReportListenerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeviceInstallationReportListenerSpec.scala
@@ -29,7 +29,7 @@ class DeviceUpdateEventListenerSpec
   val listener = new DeviceUpdateEventListener(msgPub)
 
   property("should parse and save DeviceUpdateReport messages and is idempotent") {
-    val deviceUuid = createDeviceOk(genDeviceT.generate)
+    val deviceUuid = createDeviceOk(genCreateDevice.generate)
     val correlationId = genCorrelationId.generate
     val message = genDeviceInstallationReport(correlationId, "0", deviceUuid).generate
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParserSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParserSpec.scala
@@ -180,12 +180,12 @@ class GroupExpressionRunSpec extends FunSuite with Matchers with DatabaseSpec wi
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(300, Millis), interval = Span(30, Millis))
 
   val device0 =
-    DeviceGenerators.genDeviceT
+    DeviceGenerators.genCreateDevice
       .sample
       .get
       .copy(deviceId = DeviceOemId("deviceABC"))
   val device1 =
-    DeviceGenerators.genDeviceT
+    DeviceGenerators.genCreateDevice
       .sample
       .get
       .copy(deviceId = DeviceOemId("deviceDEF"))

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepositorySpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepositorySpec.scala
@@ -11,7 +11,7 @@ package com.advancedtelematic.ota.deviceregistry.db
 import java.time.Instant
 
 import com.advancedtelematic.libats.test.DatabaseSpec
-import com.advancedtelematic.ota.deviceregistry.data.DeviceGenerators.{genDeviceId, genDeviceT}
+import com.advancedtelematic.ota.deviceregistry.data.DeviceGenerators.{genDeviceId, genCreateDevice}
 import com.advancedtelematic.ota.deviceregistry.data.Namespaces
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
@@ -24,7 +24,7 @@ class DeviceRepositorySpec extends FunSuite with DatabaseSpec with ScalaFutures 
 
   test("updateLastSeen sets activated_at the first time only") {
 
-    val device = genDeviceT.sample.get.copy(deviceId = genDeviceId.sample.get)
+    val device = genCreateDevice.sample.get.copy(deviceId = genDeviceId.sample.get)
     val setTwice = for {
       uuid   <- DeviceRepository.create(Namespaces.defaultNs, device)
       first  <- DeviceRepository.updateLastSeen(uuid, Instant.now()).map(_._1)
@@ -40,7 +40,7 @@ class DeviceRepositorySpec extends FunSuite with DatabaseSpec with ScalaFutures 
 
   test("activated_at can be counted") {
 
-    val device = genDeviceT.sample.get.copy(deviceId = genDeviceId.sample.get)
+    val device = genCreateDevice.sample.get.copy(deviceId = genDeviceId.sample.get)
     val createDevice = for {
       uuid <- DeviceRepository.create(Namespaces.defaultNs, device)
       now = Instant.now()

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateEcuInfoFromDirectorSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateEcuInfoFromDirectorSpec.scala
@@ -1,0 +1,73 @@
+package com.advancedtelematic.ota.deviceregistry.db
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.libats.test.{DatabaseSpec, LongTest}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.Ecu
+import com.advancedtelematic.ota.deviceregistry.data.GeneratorOps._
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceGenerators, Namespaces}
+import com.advancedtelematic.ota.deviceregistry.util.FakeDirectorClient
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.{EitherValues, FunSuite, Matchers}
+
+class MigrateEcuInfoFromDirectorSpec
+    extends FunSuite
+    with DeviceGenerators
+    with ScalaFutures
+    with DatabaseSpec
+    with Matchers
+    with EitherValues
+    with Namespaces
+    with Eventually
+    with LongTest {
+
+  implicit val system: ActorSystem                     = ActorSystem(this.getClass.getSimpleName)
+  implicit val materializer: ActorMaterializer         = ActorMaterializer()
+  import system.dispatcher
+
+  test("should store the ECUs from director") {
+    val newDevice = genCreateDeviceWithNEcus(20).generate
+    val deviceId  = db.run(DeviceRepository.create(defaultNs, newDevice)).futureValue
+
+    val ecusHead   = newDevice.ecus.head
+    val primaryEcu = Ecu(deviceId, ecusHead.ecuId, ecusHead.ecuType, primary = true, ecusHead.clientKey)
+    val secondaryEcus =
+      newDevice.ecus.tail.map(e => Ecu(deviceId, e.ecuId, e.ecuType, primary = false, e.clientKey))
+    val allEcus = primaryEcu +: secondaryEcus
+
+    val director = new FakeDirectorClient
+    director.addEcus(defaultNs, deviceId, allEcus: _*)
+
+    val migrator = new MigrateEcuInfoFromDirector(director)
+    migrator.run.futureValue
+
+    eventually {
+      val result = db
+        .run(EcuRepository.listEcusForDevice(deviceId, None, None))
+        .map(_.values)
+        .futureValue
+      result should contain theSameElementsAs allEcus
+    }
+  }
+
+  test("the migration is idempotent") {
+    val newDevice = genCreateDeviceWithNEcus(1).generate
+    val deviceId  = db.run(DeviceRepository.create(defaultNs, newDevice)).futureValue
+    val ecusHead  = newDevice.ecus.head
+    val ecu       = Ecu(deviceId, ecusHead.ecuId, ecusHead.ecuType, primary = true, ecusHead.clientKey)
+
+    val director = new FakeDirectorClient
+    val migrator = new MigrateEcuInfoFromDirector(director)
+
+    migrator.saveEcu(ecu).futureValue
+    val foundEcu1 = db.run(EcuRepository.listEcusForDevice(deviceId, None, None)).futureValue.values
+    foundEcu1 should contain only ecu
+
+    // Repeat to make sure the method is idempotent when given the same value
+    migrator.saveEcu(ecu).futureValue
+    val foundEcu2 = db.run(EcuRepository.listEcusForDevice(deviceId, None, None)).futureValue.values
+    foundEcu2 should contain only ecu
+
+  }
+
+}

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateOldInstallationReportsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateOldInstallationReportsSpec.scala
@@ -40,9 +40,6 @@ class MigrateOldInstallationReportsSpec
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
-  private val genEcuId: Gen[EcuIdentifier] =
-    Gen.listOfN(64, Gen.alphaNumChar).map(_.mkString("")).map(validatedEcuIdentifier.from(_).right.get)
-
   private val genOperationResultPair: Gen[(EcuIdentifier, OperationResult)] =
     genEcuId.flatMap(ecuId => genOperationResult.map(ecuId -> _))
 
@@ -121,7 +118,7 @@ class MigrateOldInstallationReportsSpec
   }
 
   test("should store the reports in the new format and be idempotent") {
-    val deviceT  = genDeviceT.sample.get
+    val deviceT  = genCreateDevice.sample.get
     val deviceId = db.run(DeviceRepository.create(defaultNs, deviceT)).futureValue
 
     val auditor = new FakeAuditorClient

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/util/FakeAuditorClient.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/util/FakeAuditorClient.scala
@@ -1,4 +1,5 @@
 package com.advancedtelematic.ota.deviceregistry.util
+
 import java.util.concurrent.ConcurrentHashMap
 
 import akka.http.scaladsl.util.FastFuture

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/util/FakeDirectorClient.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/util/FakeDirectorClient.scala
@@ -1,0 +1,35 @@
+package com.advancedtelematic.ota.deviceregistry.util
+
+import java.util.concurrent.ConcurrentHashMap
+
+import akka.http.scaladsl.util.FastFuture
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libtuf.data.TufDataType.TufKey
+import com.advancedtelematic.ota.deviceregistry.client.{DirectorClient, EcuInfo}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.Ecu
+
+import scala.collection.JavaConverters._
+import scala.collection._
+import scala.concurrent.Future
+
+class FakeDirectorClient extends DirectorClient {
+
+  private val ecus = new ConcurrentHashMap[(Namespace, DeviceId, EcuIdentifier), Ecu]().asScala
+
+  def addEcus(ns: Namespace, deviceId: DeviceId, newEcus: Ecu*): Unit =
+    newEcus.foreach(ecu => ecus.put((ns, deviceId, ecu.ecuId), ecu))
+
+  override def getEcuInfo(ns: Namespace, did: DeviceId): Future[Seq[EcuInfo]] = FastFuture.successful {
+    ecus
+      .filter{ case ((_ns, _did, _), _) => _ns == ns && _did == did }
+      .values
+      .map(ecu => EcuInfo(ecu.ecuId, ecu.ecuType, ecu.primary))
+      .toSeq
+  }
+
+  override def getPublicKey(ns: Namespace, did: DeviceId, ecuId: EcuIdentifier): Future[TufKey] = FastFuture.successful {
+    ecus.getOrElse((ns, did, ecuId), throw new IllegalArgumentException(s"No ECU for ns: $ns deviceId: $did ecuId: $ecuId.")).tufKey
+  }
+}


### PR DESCRIPTION
Sorry for the huge PR! We're now storing the ECU info in device-registry, so in this PR:

- Now we require the ECU info when creating a new device.
- Migrate the ECU info from director to device-registry.
- Create a new endpoint to get the ECU info.

**Note: This changes the way we create devices, so other services might need to change when we merge this?**