### PR TITLE
Archive indexed events when deleting a device.

### DIFF
--- a/src/main/resources/db/migration/V28__add_indexed_events_archive.sql
+++ b/src/main/resources/db/migration/V28__add_indexed_events_archive.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IndexedEventsArchive (
+  device_uuid    CHAR(36)     NOT NULL COLLATE utf8_bin,
+  event_id       CHAR(36)     NOT NULL COLLATE utf8_unicode_ci ,
+  correlation_id VARCHAR(256) NOT NULL,
+  event_type     VARCHAR(256) DEFAULT NULL,
+  created_at     DATETIME(3)  NOT NULL DEFAULT current_timestamp(3),
+  updated_at     DATETIME(3)  NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
+
+  PRIMARY KEY (device_uuid, event_id),
+  INDEX(correlation_id)
+);

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
@@ -194,6 +194,7 @@ object DeviceRepository {
   def delete(ns: Namespace, uuid: DeviceId)(implicit ec: ExecutionContext): DBIO[Unit] = {
     val dbIO = for {
       _ <- exists(ns, uuid)
+      _ <- EventJournal.archiveIndexedEvents(uuid)
       _ <- EventJournal.deleteEvents(uuid)
       _ <- GroupMemberRepository.removeGroupMemberAll(uuid)
       _ <- PublicCredentialsRepository.delete(uuid)


### PR DESCRIPTION
There is a FK constraint from the `IndexedEvents` table to the `EventJournal` table, so I was seeing some errors in the logs.

In the future, wouldn't it be an improvement to delete in the SQL when creating the constrains? Or is there any advantage to doing it through Slick?