### PR TITLE
Use different endpoint for failed devices CSV export.

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
@@ -5,8 +5,8 @@ import com.advancedtelematic.libats.codecs.CirceCodecs.{refinedDecoder, refinedE
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStat, UpdateDevice}
 
 object Codecs {
-  private[this] implicit val deviceIdEncoder = Encoder.encodeString.contramap[Device.DeviceOemId](_.underlying)
-  private[this] implicit val deviceIdDecoder = Decoder.decodeString.map(Device.DeviceOemId.apply)
+  implicit val deviceIdEncoder = Encoder.encodeString.contramap[Device.DeviceOemId](_.underlying)
+  implicit val deviceIdDecoder = Decoder.decodeString.map(Device.DeviceOemId.apply)
 
   implicit val deviceTEncoder = io.circe.generic.semiauto.deriveEncoder[DeviceT]
   implicit val deviceTDecoder = io.circe.generic.semiauto.deriveDecoder[DeviceT]

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CsvSerializer.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CsvSerializer.scala
@@ -1,8 +1,7 @@
 package com.advancedtelematic.ota.deviceregistry.data
 
-import akka.util.ByteString
+import cats.Show
 import cats.syntax.show._
-import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 
 trait CsvSerializer[T] {
@@ -13,12 +12,16 @@ object CsvSerializer {
   val fieldSeparator = ";"
   val recordSeparator = "\n"
 
-  implicit val deviceFailureSerializer: CsvSerializer[(DeviceId, DeviceOemId, String)] =
-    (a: (DeviceId, DeviceOemId, String)) => Seq(a._1.show, a._2.show, a._3)
+  implicit val showString: Show[String] = identity _
 
-  def header(header: String*): ByteString = ByteString(header.mkString("", fieldSeparator, recordSeparator))
+  implicit def tuple2Serializer[A: Show, B: Show]: CsvSerializer[(A, B)] =
+    (t: (A, B)) => t._1.show +: t._2.show +: Nil
 
-  def asCsvRow[T: CsvSerializer](row: T)(implicit serializer: CsvSerializer[T]): ByteString =
-    ByteString(serializer.toCsvRow(row).mkString("", fieldSeparator, recordSeparator))
+  implicit val deviceIdFailureSerializer = implicitly[CsvSerializer[(DeviceOemId, String)]]
 
+  def asCsv[T](header: Seq[String], rows: Seq[T])(implicit serializer: CsvSerializer[T]): String = {
+    val head = header.mkString(fieldSeparator)
+    val body = rows.map(serializer.toCsvRow(_).mkString(fieldSeparator))
+    (head +: body).mkString(recordSeparator)
+  }
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
@@ -117,15 +117,13 @@ object InstallationReportRepository {
       .map(_.installationReport)
       .paginateResult(offset.orDefaultOffset, limit.orDefaultLimit)
 
-  def fetchDeviceFailures(correlationId: CorrelationId)(implicit ec: ExecutionContext, db: Database): Source[(DeviceId, DeviceOemId, String), NotUsed] =
-    Source.fromPublisher(db.stream {
+  def fetchDeviceFailures(correlationId: CorrelationId)(implicit ec: ExecutionContext): DBIO[Seq[(DeviceOemId, String)]] =
       deviceInstallationResults
         .filter(_.correlationId === correlationId)
         .filter(_.success === false)
         .join(DeviceRepository.devices)
         .on(_.deviceUuid === _.uuid)
-        .map{ case (r, d) => (d.uuid, d.deviceId, r.resultCode) }
+        .map{ case (r, d) => (d.deviceId, r.resultCode) }
         .result
-    })
 
 }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -183,7 +183,7 @@ trait DeviceRequests { self: ResourceSpec =>
     Get(Resource.uri(api, "stats").withQuery(Query("correlationId" -> correlationId.toString, "level" -> level.toString)))
 
   def getFailedExport(correlationId: CorrelationId): HttpRequest =
-    Get(Resource.uri(api, "stats").withQuery(Query("correlationId" -> correlationId.toString)))
+    Get(Resource.uri(api, "failed-installations").withQuery(Query("correlationId" -> correlationId.toString)))
       .withHeaders(Accept(MediaTypes.`text/csv`))
 
   def getReportBlob(deviceId: DeviceId): HttpRequest =

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/InstallationReportSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/InstallationReportSpec.scala
@@ -75,9 +75,9 @@ class InstallationReportSpec extends ResourcePropSpec with ScalaFutures with Eve
     val correlationId = genCorrelationId.sample.get
     val resultCodes = Seq("0", "1", "2", "2", "3", "3", "3")
     val createDevices = genConflictFreeDeviceTs(resultCodes.length).sample.get
-    val deviceIds = createDevices.map(createDeviceOk)
-    val rows = deviceIds.zip(createDevices).zip(resultCodes).map { case ((did, cd), rc) => (did, cd.deviceId, rc) }
-    val deviceReports = rows.map { case (did, _, rc) => genDeviceInstallationReport(correlationId, rc, did) }.map(_.sample.get)
+    val deviceUuids = createDevices.map(createDeviceOk)
+    val rows = deviceUuids.zip(createDevices).zip(resultCodes).map { case ((uuid, cd), rc) => (uuid, cd.deviceId, rc) }
+    val deviceReports = rows.map { case (uuid, _, rc) => genDeviceInstallationReport(correlationId, rc, uuid) }.map(_.sample.get)
 
     deviceReports.foreach(listener.apply)
 
@@ -85,7 +85,7 @@ class InstallationReportSpec extends ResourcePropSpec with ScalaFutures with Eve
       getFailedExport(correlationId) ~> route ~> check {
         status shouldBe OK
         contentType shouldBe ContentTypes.`text/csv(UTF-8)`
-        val expected = rows.filter(_._3 != "0").map { case (did, cd, rc) => did.show + ";" + cd.show + ";" + rc }
+        val expected = rows.filter(_._3 != "0").map { case (_, cd, rc) => cd.show + ";" + rc }
         val result = entityAs[ByteString].utf8String.split("\n")
         result.tail should contain allElementsOf expected
       }


### PR DESCRIPTION
- Using `/api/v1/devices/failed-installations` endpoint for export.
- Endpoint as CSV or JSON (for completeness, but there's no use case for the JSON).
- Export contains only deviceId and failure code.
- Not using ByteString here, could think how to refactor it in the future.