### PR TITLE
Hefty refactor

### DIFF
--- a/src/main/resources/db/migration/V30__device_type_as_string.sql
+++ b/src/main/resources/db/migration/V30__device_type_as_string.sql
@@ -1,0 +1,5 @@
+ALTER TABLE Device
+MODIFY COLUMN device_type varchar(200) NOT NULL;
+
+UPDATE Device
+SET device_type = CASE WHEN device_type = "1" THEN "Vehicle" ELSE "Other" END;

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -33,9 +33,9 @@ import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsLevel.InstallationStatsLevel
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStatsLevel, SearchParams, UpdateDevice}
 import com.advancedtelematic.ota.deviceregistry.data.Device.{ActiveDeviceCount, DeviceOemId}
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.{CsvSerializer, PackageId}
+import com.advancedtelematic.ota.deviceregistry.data.{CsvSerializer, GroupExpression, PackageId}
 import com.advancedtelematic.ota.deviceregistry.db._
 import com.advancedtelematic.ota.deviceregistry.messages.{DeleteDeviceRequest, DeviceCreated}
 import eu.timepit.refined.api.Refined

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupMembership.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupMembership.scala
@@ -4,9 +4,9 @@ import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.ota.deviceregistry.common.Errors
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId, Name}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupType}
+import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupExpression, GroupName, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.{DeviceRepository, GroupInfoRepository, GroupMemberRepository}
 import slick.jdbc.MySQLProfile.api._
 
@@ -22,7 +22,7 @@ protected class DynamicMembership(implicit db: Database, ec: ExecutionContext) e
 
   def create(
       groupId: GroupId,
-      name: Name,
+      name: GroupName,
       namespace: Namespace,
       expression: GroupExpression
   ): Future[GroupId] = db.run {
@@ -52,7 +52,7 @@ protected class StaticMembership(implicit db: Database, ec: ExecutionContext) ex
   override def removeMember(group: Group, deviceId: DeviceId): Future[Unit] =
     db.run(GroupMemberRepository.removeGroupMember(group.id, deviceId))
 
-  def create(groupId: GroupId, name: Name, namespace: Namespace): Future[GroupId] = db.run {
+  def create(groupId: GroupId, name: GroupName, namespace: Namespace): Future[GroupId] = db.run {
     GroupInfoRepository.create(groupId, name, namespace, GroupType.static, expression = None)
   }
 }
@@ -65,7 +65,7 @@ class GroupMembership(implicit val db: Database, ec: ExecutionContext) {
       case g                                 => fn(g, new DynamicMembership())
     }
 
-  def create(name: Group.Name,
+  def create(name: GroupName,
              namespace: Namespace,
              groupType: GroupType,
              expression: Option[GroupExpression]): Future[GroupId] =

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
@@ -11,33 +11,34 @@ package com.advancedtelematic.ota.deviceregistry
 import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
-import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.http.scaladsl.unmarshalling.{FromStringUnmarshaller, Unmarshaller}
+import cats.syntax.either._
 import com.advancedtelematic.libats.auth.{AuthedNamespaceScope, Scopes}
 import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId, Name}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.data.SortBy.SortBy
 import com.advancedtelematic.ota.deviceregistry.data._
 import com.advancedtelematic.ota.deviceregistry.db.GroupInfoRepository
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.{Decoder, Encoder}
 import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
-import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 
 class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], deviceNamespaceAuthorizer: Directive1[DeviceId])
                     (implicit ec: ExecutionContext, db: Database) extends Directives {
-
-  import com.advancedtelematic.libats.http.RefinedMarshallingSupport._
-  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 
   private val GroupIdPath = {
     def groupAllowed(groupId: GroupId): Future[Namespace] = db.run(GroupInfoRepository.groupInfoNamespace(groupId))
     AllowUUIDPath(GroupId)(namespaceExtractor, groupAllowed)
   }
 
-  implicit val groupTypeParamUnmarshaller: Unmarshaller[String, GroupType] = Unmarshaller.strict[String, GroupType](GroupType.withName)
-  implicit val sortByUnmarshaller: Unmarshaller[String, SortBy] = Unmarshaller.strict {
+  implicit val groupTypeUnmarshaller: FromStringUnmarshaller[GroupType] = Unmarshaller.strict(GroupType.withName)
+  implicit val groupNameUnmarshaller: FromStringUnmarshaller[GroupName] = Unmarshaller.strict(GroupName.validatedGroupName.from(_).valueOr(throw _))
+
+  implicit val sortByUnmarshaller: FromStringUnmarshaller[SortBy] = Unmarshaller.strict {
     _.toLowerCase match {
       case "name"      => SortBy.Name
       case "createdat" => SortBy.CreatedAt
@@ -58,13 +59,13 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
   def getGroup(groupId: GroupId): Route =
     complete(db.run(GroupInfoRepository.findByIdAction(groupId)))
 
-  def createGroup(groupName: Name,
+  def createGroup(groupName: GroupName,
                   namespace: Namespace,
                   groupType: GroupType,
                   expression: Option[GroupExpression]): Route =
     complete(StatusCodes.Created -> groupMembership.create(groupName, namespace, groupType, expression))
 
-  def renameGroup(groupId: GroupId, newGroupName: Name): Route =
+  def renameGroup(groupId: GroupId, newGroupName: GroupName): Route =
     complete(db.run(GroupInfoRepository.renameGroup(groupId, newGroupName)))
 
   def countDevices(groupId: GroupId): Route =
@@ -102,7 +103,7 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
             }
           }
         } ~
-        (scope.put & path("rename") & parameter('groupName.as[Name])) { groupName =>
+        (scope.put & path("rename") & parameter('groupName.as[GroupName])) { groupName =>
           renameGroup(groupId, groupName)
         } ~
         (scope.get & path("count") & pathEnd) {
@@ -112,7 +113,7 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
     }
 }
 
-case class CreateGroup(name: Group.Name, groupType: GroupType, expression: Option[GroupExpression])
+case class CreateGroup(name: GroupName, groupType: GroupType, expression: Option[GroupExpression])
 
 object CreateGroup {
   import GroupType._

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/MarshallingSupport.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/MarshallingSupport.scala
@@ -1,0 +1,59 @@
+package com.advancedtelematic.ota.deviceregistry
+
+import akka.http.scaladsl.marshalling.{Marshaller, ToResponseMarshaller}
+import akka.http.scaladsl.model.headers.{ContentDispositionTypes, `Content-Disposition`}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import akka.http.scaladsl.unmarshalling.{FromStringUnmarshaller, Unmarshaller}
+import cats.syntax.either._
+import com.advancedtelematic.libats.data.DataType.CorrelationId
+import com.advancedtelematic.libats.http.UUIDKeyAkka._
+import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsLevel
+import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsLevel.InstallationStatsLevel
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
+import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
+import com.advancedtelematic.ota.deviceregistry.data.SortBy.SortBy
+import com.advancedtelematic.ota.deviceregistry.data._
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+
+
+object MarshallingSupport {
+
+  implicit val groupIdUnmarshaller: Unmarshaller[String, GroupId] = GroupId.unmarshaller
+
+  implicit val correlationIdUnmarshaller: FromStringUnmarshaller[CorrelationId] = Unmarshaller.strict {
+    CorrelationId.fromString(_).leftMap(new IllegalArgumentException(_)).valueOr(throw _)
+  }
+
+  implicit val groupExpressionUnmarshaller: FromStringUnmarshaller[GroupExpression] = Unmarshaller.strict(GroupExpression(_).valueOr(throw _))
+
+  implicit val installationStatsLevelUnmarshaller: FromStringUnmarshaller[InstallationStatsLevel] =
+    Unmarshaller.strict {
+      _.toLowerCase match {
+        case "device" => InstallationStatsLevel.Device
+        case "ecu"    => InstallationStatsLevel.Ecu
+        case s        => throw new IllegalArgumentException(s"Invalid value for installation stats level parameter: $s.")
+      }
+    }
+
+  val installationFailureMarshaller = implicitly[ToResponseMarshaller[Seq[(DeviceOemId, String)]]]
+
+  implicit val installationFailureCsvMarshaller: ToResponseMarshaller[Seq[(DeviceOemId, String, String)]] =
+    Marshaller.withFixedContentType(ContentTypes.`text/csv(UTF-8)`) { t =>
+      val csv = CsvSerializer.asCsv(Seq("Device ID", "Failure Code", "Failure Description"), t)
+      val e = HttpEntity(ContentTypes.`text/csv(UTF-8)`, csv)
+      val h = `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "device-failures.csv"))
+      HttpResponse(headers = h :: Nil, entity = e)
+    }
+
+  implicit val groupTypeUnmarshaller: FromStringUnmarshaller[GroupType] = Unmarshaller.strict(GroupType.withName)
+  implicit val groupNameUnmarshaller: FromStringUnmarshaller[GroupName] = Unmarshaller.strict(GroupName(_).valueOr(throw _))
+
+  implicit val sortByUnmarshaller: FromStringUnmarshaller[SortBy] = Unmarshaller.strict {
+    _.toLowerCase match {
+      case "name"      => SortBy.Name
+      case "createdat" => SortBy.CreatedAt
+      case s           => throw new IllegalArgumentException(s"Invalid value for sorting parameter: '$s'.")
+    }
+  }
+
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResource.scala
@@ -44,8 +44,8 @@ class PublicCredentialsResource(
 )(implicit db: Database, mat: ActorMaterializer, ec: ExecutionContext) {
   import PublicCredentialsResource._
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-  lazy val base64Decoder = Base64.getDecoder()
-  lazy val base64Encoder = Base64.getEncoder()
+  lazy val base64Decoder = Base64.getDecoder
+  lazy val base64Encoder = Base64.getEncoder
 
   def fetchPublicCredentials(uuid: DeviceId): Route =
     complete(db.run(PublicCredentialsRepository.findByUuid(uuid)).map { creds =>

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
@@ -10,8 +10,7 @@ package com.advancedtelematic.ota.deviceregistry.common
 
 import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.{EntityAlreadyExists, MissingEntity, RawError}
-import com.advancedtelematic.ota.deviceregistry.data.Group
-import com.advancedtelematic.ota.deviceregistry.data.Group.GroupExpression
+import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupExpression}
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.db.GroupMemberRepository.GroupMember
 import com.advancedtelematic.ota.deviceregistry.db.PublicCredentialsRepository.DevicePublicCredentials

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
@@ -1,19 +1,22 @@
 package com.advancedtelematic.ota.deviceregistry.data
 
+import com.advancedtelematic.ota.deviceregistry.data.DataType._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
-import com.advancedtelematic.libats.codecs.CirceCodecs.{refinedDecoder, refinedEncoder}
-import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStat, UpdateDevice}
 
 object Codecs {
-  private implicit val deviceIdEncoder = Encoder.encodeString.contramap[Device.DeviceOemId](_.underlying)
-  private implicit val deviceIdDecoder = Decoder.decodeString.map(Device.DeviceOemId.apply)
+  implicit val deviceTEncoder: Encoder[DeviceT] = deriveEncoder[DeviceT]
+  implicit val deviceTDecoder: Decoder[DeviceT] = deriveDecoder[DeviceT]
 
-  implicit val deviceTEncoder = io.circe.generic.semiauto.deriveEncoder[DeviceT]
-  implicit val deviceTDecoder = io.circe.generic.semiauto.deriveDecoder[DeviceT]
+  implicit val createGroupEncoder: Encoder[CreateGroup] = deriveEncoder
+  implicit val createGroupDecoder: Decoder[CreateGroup] = deriveDecoder
 
-  implicit val updateDeviceEncoder = io.circe.generic.semiauto.deriveEncoder[UpdateDevice]
-  implicit val updateDeviceDecoder = io.circe.generic.semiauto.deriveDecoder[UpdateDevice]
+  implicit val updateDeviceEncoder: Encoder[UpdateDevice] = deriveEncoder[UpdateDevice]
+  implicit val updateDeviceDecoder: Decoder[UpdateDevice] = deriveDecoder[UpdateDevice]
 
-  implicit val installationStatEncoder = io.circe.generic.semiauto.deriveEncoder[InstallationStat]
-  implicit val installationStatDecoder = io.circe.generic.semiauto.deriveDecoder[InstallationStat]
+  implicit val installationStatEncoder: Encoder[InstallationStat] = deriveEncoder[InstallationStat]
+  implicit val installationStatDecoder: Decoder[InstallationStat] = deriveDecoder[InstallationStat]
+
+  implicit val activeDeviceCountEncoder: Encoder[ActiveDeviceCount] = Encoder.encodeInt.contramap[ActiveDeviceCount](_.deviceCount)
+  implicit val activeDeviceCountDecoder: Decoder[ActiveDeviceCount] = Decoder.decodeInt.map(ActiveDeviceCount.apply)
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CredentialsType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CredentialsType.scala
@@ -8,10 +8,12 @@
 
 package com.advancedtelematic.ota.deviceregistry.data
 
-final object CredentialsType extends Enumeration {
+import io.circe.{Decoder, Encoder}
+
+object CredentialsType extends Enumeration {
   type CredentialsType = Value
   val PEM, OAuthClientCredentials = Value
 
-  implicit val EncoderInstance = io.circe.Encoder.enumEncoder(CredentialsType)
-  implicit val DecoderInstance = io.circe.Decoder.enumDecoder(CredentialsType)
+  implicit val credentialsTypeEncoder: Encoder[CredentialsType] = Encoder.enumEncoder(CredentialsType)
+  implicit val credentialsTypeDecoder: Decoder[CredentialsType] = Decoder.enumDecoder(CredentialsType)
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CsvSerializer.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CsvSerializer.scala
@@ -2,7 +2,6 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import cats.Show
 import cats.syntax.show._
-import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 
 trait CsvSerializer[T] {
   def toCsvRow(value: T): Seq[String]

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.libats.data.EcuIdentifier
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, Event}
 import com.advancedtelematic.ota.deviceregistry.data.CredentialsType.CredentialsType
 import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType.IndexedEventType
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
+import com.advancedtelematic.ota.deviceregistry.data.DeviceType.DeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import eu.timepit.refined.api.Refined
@@ -16,9 +16,34 @@ import eu.timepit.refined.string.Regex
 import io.circe.Json
 
 object DataType {
+
+  final case class DeviceT(uuid: Option[DeviceId] = None,
+                           deviceName: DeviceName,
+                           deviceId: DeviceOemId,
+                           deviceType: DeviceType = DeviceType.Other,
+                           credentials: Option[String] = None,
+                           credentialsType: Option[CredentialsType] = None)
+
+  case class ActiveDeviceCount(deviceCount: Int) extends AnyVal
+
+  final case class UpdateDevice(deviceName: DeviceName)
+
+  case class CreateGroup(name: GroupName, groupType: GroupType, expression: Option[GroupExpression])
+
   case class IndexedEvent(device: DeviceId, eventID: String, eventType: IndexedEventType, correlationId: Option[CorrelationId])
 
   case class InstallationStat(resultCode: String, total: Int, success: Boolean)
+
+  final case class DeviceInstallationResult(correlationId: CorrelationId, resultCode: String, deviceId: DeviceId, success: Boolean, receivedAt: Instant, installationReport: Json)
+  final case class EcuInstallationResult(correlationId: CorrelationId, resultCode: String, deviceId: DeviceId, ecuId: EcuIdentifier, success: Boolean)
+
+  final case class SearchParams(oemId: Option[DeviceOemId], grouped: Option[Boolean], groupType: Option[GroupType],
+                                groupId: Option[GroupId], regex: Option[String Refined Regex], offset: Option[Long], limit: Option[Long]) {
+    if (oemId.isDefined) {
+      require(groupId.isEmpty, "Invalid parameters: groupId must be empty when searching by deviceId.")
+      require(regex.isEmpty, "Invalid parameters: regex must be empty when searching by deviceId.")
+    }
+  }
 
   object IndexedEventType extends Enumeration {
     type IndexedEventType = Value
@@ -32,27 +57,8 @@ object DataType {
     case object Ecu extends InstallationStatsLevel
   }
 
-  final case class DeviceT(uuid: Option[DeviceId] = None,
-                           deviceName: DeviceName,
-                           deviceId: DeviceOemId,
-                           deviceType: DeviceType = DeviceType.Other,
-                           credentials: Option[String] = None,
-                           credentialsType: Option[CredentialsType] = None)
-
-  final case class UpdateDevice(deviceName: DeviceName)
-
   implicit val eventShow: Show[Event] = Show { event =>
     s"(device=${event.deviceUuid},eventId=${event.eventId},eventType=${event.eventType})"
   }
 
-  final case class DeviceInstallationResult(correlationId: CorrelationId, resultCode: String, deviceId: DeviceId, success: Boolean, receivedAt: Instant, installationReport: Json)
-  final case class EcuInstallationResult(correlationId: CorrelationId, resultCode: String, deviceId: DeviceId, ecuId: EcuIdentifier, success: Boolean)
-
-  final case class SearchParams(oemId: Option[DeviceOemId], grouped: Option[Boolean], groupType: Option[GroupType],
-                          groupId: Option[GroupId], regex: Option[String Refined Regex], offset: Option[Long], limit: Option[Long]) {
-    if (oemId.isDefined) {
-      require(groupId.isEmpty, "Invalid parameters: groupId must be empty when searching by deviceId.")
-      require(regex.isEmpty, "Invalid parameters: regex must be empty when searching by deviceId.")
-    }
-  }
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.libats.data.EcuIdentifier
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, Event}
 import com.advancedtelematic.ota.deviceregistry.data.CredentialsType.CredentialsType
 import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType.IndexedEventType
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceName, DeviceOemId, DeviceType}
+import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import eu.timepit.refined.api.Refined

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Device.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Device.scala
@@ -11,12 +11,14 @@ package com.advancedtelematic.ota.deviceregistry.data
 import java.time.{Instant, OffsetDateTime}
 import java.util.UUID
 
-import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import cats.Show
 import cats.syntax.show._
+import com.advancedtelematic.libats.codecs.CirceCodecs._
 import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus._
+import com.advancedtelematic.ota.deviceregistry.data.DeviceType.DeviceType
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 
 final case class Device(namespace: Namespace,
@@ -31,29 +33,11 @@ final case class Device(namespace: Namespace,
 
 object Device {
 
-  final case class DeviceOemId(underlying: String) extends AnyVal
-  implicit val showDeviceOemId: Show[DeviceOemId] = deviceId => deviceId.underlying
+  implicit val deviceEncoder: Encoder[Device] = deriveEncoder[Device]
+  implicit val deviceDecoder: Decoder[Device] = deriveDecoder[Device]
 
-  type DeviceType = DeviceType.DeviceType
-
-  final object DeviceType extends Enumeration {
-    // TODO: We should encode Enums as strings, not Ints
-    // Moved this from SlickEnum, because this should **NOT** be used
-    // It's difficult to read this when reading from the database and the Id is not stable when we add/remove
-    // values from the enum
-    import slick.jdbc.MySQLProfile.MappedJdbcType
-    import slick.jdbc.MySQLProfile.api._
-
-    implicit val enumMapper = MappedJdbcType.base[Value, Int](_.id, this.apply)
-
-    type DeviceType = Value
-    val Other, Vehicle = Value
-
-    implicit val JsonEncoder = Encoder.enumEncoder(DeviceType)
-    implicit val JsonDecoder = Decoder.enumDecoder(DeviceType)
-  }
-
-  implicit val showDeviceType = Show.fromToString[DeviceType.Value]
+  implicit def DeviceOrdering(implicit ord: Ordering[UUID]): Ordering[Device] =
+    (d1, d2) => ord.compare(d1.uuid.uuid, d2.uuid.uuid)
 
   implicit val showDevice: Show[Device] = Show.show[Device] {
     case d if d.deviceType == DeviceType.Vehicle =>
@@ -61,26 +45,6 @@ object Device {
     case d => s"Device: uuid=${d.uuid.show}, lastSeen=${d.lastSeen}"
   }
 
-  implicit val EncoderInstance = {
-    import com.advancedtelematic.libats.codecs.CirceCodecs._
-    io.circe.generic.semiauto.deriveEncoder[Device]
-  }
-  implicit val DecoderInstance = {
-    import com.advancedtelematic.libats.codecs.CirceCodecs._
-    io.circe.generic.semiauto.deriveDecoder[Device]
-  }
+  implicit val showOffsetDateTable: Show[OffsetDateTime] = Show.fromToString
 
-  implicit val DeviceIdOrdering: Ordering[DeviceOemId] = (id1, id2) => id1.underlying compare id2.underlying
-
-  implicit def DeviceOrdering(implicit ord: Ordering[UUID]): Ordering[Device] =
-    (d1, d2) => ord.compare(d1.uuid.uuid, d2.uuid.uuid)
-
-  implicit val showOffsetDateTable: Show[OffsetDateTime] = odt => odt.toString
-
-  case class ActiveDeviceCount(deviceCount: Int) extends AnyVal
-
-  object ActiveDeviceCount {
-    implicit val EncoderInstance = Encoder.encodeInt.contramap[ActiveDeviceCount](_.deviceCount)
-    implicit val DecoderInstance = Decoder.decodeInt.map(ActiveDeviceCount.apply)
-  }
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Device.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Device.scala
@@ -15,9 +15,8 @@ import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import cats.Show
 import cats.syntax.show._
 import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceName, DeviceOemId, DeviceType}
+import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
 import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus._
-import eu.timepit.refined.api.{Refined, Validate}
 import io.circe.{Decoder, Encoder}
 
 final case class Device(namespace: Namespace,
@@ -34,15 +33,6 @@ object Device {
 
   final case class DeviceOemId(underlying: String) extends AnyVal
   implicit val showDeviceOemId: Show[DeviceOemId] = deviceId => deviceId.underlying
-
-  case class ValidDeviceName()
-  type DeviceName = Refined[String, ValidDeviceName]
-  implicit val validDeviceName: Validate.Plain[String, ValidDeviceName] =
-    Validate.fromPredicate(
-      name => name.length < 200,
-      name => s"$name is not a valid DeviceName since it is longer than 200 characters",
-      ValidDeviceName()
-    )
 
   type DeviceType = DeviceType.DeviceType
 

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceName.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceName.scala
@@ -1,0 +1,24 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import com.advancedtelematic.libats.codecs.CirceValidatedGeneric
+import com.advancedtelematic.libats.data.{ValidatedGeneric, ValidationError}
+import io.circe.{Decoder, Encoder}
+
+final case class DeviceName private(value: String) extends AnyVal
+
+object DeviceName {
+
+  implicit val validatedDeviceType = new ValidatedGeneric[DeviceName, String] {
+    override def to(deviceType: DeviceName): String = deviceType.value
+    override def from(s: String): Either[ValidationError, DeviceName] = apply(s)
+  }
+
+  def apply(s: String): Either[ValidationError, DeviceName] =
+    if (s.length > 200)
+      Left(ValidationError(s"$s is not a valid DeviceName since it is longer than 200 characters"))
+    else
+      Right(new DeviceName(s))
+
+  implicit val deviceNameEncoder: Encoder[DeviceName] = CirceValidatedGeneric.validatedGenericEncoder
+  implicit val deviceNameDecoder: Decoder[DeviceName] = CirceValidatedGeneric.validatedGenericDecoder
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceOemId.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceOemId.scala
@@ -1,0 +1,15 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import cats.Show
+import io.circe.{Decoder, Encoder}
+
+final case class DeviceOemId(value: String) extends AnyVal
+
+object DeviceOemId {
+  implicit val showDeviceOemId: Show[DeviceOemId] = _.value
+
+  implicit val deviceIdEncoder: Encoder[DeviceOemId] = Encoder.encodeString.contramap[DeviceOemId](_.value)
+  implicit val deviceIdDecoder: Decoder[DeviceOemId] = Decoder.decodeString.map(DeviceOemId.apply)
+
+  implicit val deviceIdOrdering: Ordering[DeviceOemId] = (id1, id2) => id1.value compare id2.value
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceStatus.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceStatus.scala
@@ -12,9 +12,8 @@ import io.circe.{Decoder, Encoder}
 
 object DeviceStatus extends Enumeration {
   type DeviceStatus = Value
-
   val NotSeen, Error, UpToDate, Outdated = Value
 
-  implicit val JsonEncoder = Encoder.enumEncoder(DeviceStatus)
-  implicit val JsonDecoder = Decoder.enumDecoder(DeviceStatus)
+  implicit val deviceStatusEncoder: Encoder[DeviceStatus] = Encoder.enumEncoder(DeviceStatus)
+  implicit val deviceStatusDecoder: Decoder[DeviceStatus] = Decoder.enumDecoder(DeviceStatus)
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceType.scala
@@ -1,0 +1,17 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import cats.Show
+import com.advancedtelematic.ota.deviceregistry.data
+import io.circe.{Decoder, Encoder}
+import slick.jdbc.MySQLProfile.MappedJdbcType
+import slick.jdbc.MySQLProfile.api._
+
+object DeviceType extends Enumeration {
+  type DeviceType = Value
+  val Other, Vehicle = Value
+
+  implicit val deviceTypeEncoder: Encoder[DeviceType] = Encoder.enumEncoder(DeviceType)
+  implicit val deviceTypeDecoder: Decoder[DeviceType] = Decoder.enumDecoder(DeviceType)
+
+  implicit val deviceTypeShow: Show[DeviceType] = Show.fromToString[DeviceType]
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Group.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Group.scala
@@ -10,7 +10,6 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import java.util.UUID
 
-import akka.http.scaladsl.unmarshalling.Unmarshaller
 import com.advancedtelematic.libats.codecs.CirceCodecs._
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.UUIDKey.{UUIDKey, UUIDKeyObj}
@@ -18,26 +17,12 @@ import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
-import slick.jdbc.MySQLProfile.api._
 
 case class Group(id: GroupId,
                  groupName: GroupName,
                  namespace: Namespace,
                  groupType: GroupType,
                  expression: Option[GroupExpression] = None)
-
-object GroupType extends Enumeration {
-  type GroupType = Value
-
-  val static, dynamic = Value
-
-  implicit val groupTypeMapper = MappedColumnType.base[GroupType, String](_.toString, GroupType.withName)
-
-  implicit val groupTypeEncoder: Encoder[GroupType] = Encoder.enumEncoder(GroupType)
-  implicit val groupTypeDecoder: Decoder[GroupType] = Decoder.enumDecoder(GroupType)
-
-  implicit val groupTypeUnmarshaller: Unmarshaller[String, GroupType] = Unmarshaller.strict(GroupType.withName)
-}
 
 object Group {
 

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpression.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpression.scala
@@ -1,0 +1,27 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import com.advancedtelematic.libats.codecs.CirceValidatedGeneric
+import com.advancedtelematic.libats.data.{ValidatedGeneric, ValidationError}
+import io.circe.{Decoder, Encoder}
+
+final case class GroupExpression private (value: String) extends AnyVal
+
+object GroupExpression {
+
+  implicit val validatedGroupExpression = new ValidatedGeneric[GroupExpression, String] {
+    override def to(expression: GroupExpression): String                   = expression.value
+    override def from(s: String): Either[ValidationError, GroupExpression] = apply(s)
+  }
+
+  def apply(s: String): Either[ValidationError, GroupExpression] =
+    if (s.length < 1 || s.length > 200)
+      Left(ValidationError("The expression is too small or too big."))
+    else
+      GroupExpressionParser.parse(s).fold(
+        e => Left(ValidationError(e.desc)),
+        _ => Right(new GroupExpression(s))
+      )
+
+  implicit val groupExpressionEncoder: Encoder[GroupExpression] = CirceValidatedGeneric.validatedGenericEncoder
+  implicit val groupExpressionDecoder: Decoder[GroupExpression] = CirceValidatedGeneric.validatedGenericDecoder
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParser.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParser.scala
@@ -7,7 +7,6 @@ import cats.syntax.either._
 import com.advancedtelematic.libats.http.Errors.RawError
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.ota.deviceregistry.common.Errors
-import com.advancedtelematic.ota.deviceregistry.data.Group.GroupExpression
 import com.advancedtelematic.ota.deviceregistry.data.GroupExpressionAST._
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository.DeviceTable
 import slick.jdbc.MySQLProfile.api._

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParser.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParser.scala
@@ -31,10 +31,10 @@ object GroupExpressionAST {
 
   private def evalToScala(exp: Expression): Device => Boolean = exp match {
     case DeviceIdContains(word) =>
-      (d: Device) => d.deviceId.underlying.toLowerCase.contains(word.toLowerCase)
+      (d: Device) => d.deviceId.value.toLowerCase.contains(word.toLowerCase)
 
     case DeviceIdCharAt(c, p) =>
-      (d: Device) =>  p < d.deviceId.underlying.length && d.deviceId.underlying.charAt(p).toLower == c.toLower
+      (d: Device) =>  p < d.deviceId.value.length && d.deviceId.value.charAt(p).toLower == c.toLower
 
     case Or(cond) =>
       val evaledConds = cond.map(evalToScala)

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupName.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupName.scala
@@ -1,0 +1,24 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import com.advancedtelematic.libats.codecs.CirceValidatedGeneric
+import com.advancedtelematic.libats.data.{ValidatedGeneric, ValidationError}
+import io.circe.{Decoder, Encoder}
+
+final case class GroupName private(value: String) extends AnyVal
+
+object GroupName {
+
+  implicit val validatedGroupName = new ValidatedGeneric[GroupName, String] {
+    override def to(expression: GroupName): String = expression.value
+    override def from(s: String): Either[ValidationError, GroupName] = apply(s)
+  }
+
+  def apply(s: String): Either[ValidationError, GroupName] =
+    if (s.length < 2 || s.length > 100)
+      Left(ValidationError(s"$s should be between two and a hundred alphanumeric characters long."))
+    else
+      Right(new GroupName(s))
+
+  implicit val groupNameEncoder: Encoder[GroupName] = CirceValidatedGeneric.validatedGenericEncoder
+  implicit val groupNameDecoder: Decoder[GroupName] = CirceValidatedGeneric.validatedGenericDecoder
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupType.scala
@@ -1,0 +1,11 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import io.circe.{Decoder, Encoder}
+
+object GroupType extends Enumeration {
+  type GroupType = Value
+  val static, dynamic = Value
+
+  implicit val groupTypeEncoder: Encoder[GroupType] = Encoder.enumEncoder(GroupType)
+  implicit val groupTypeDecoder: Decoder[GroupType] = Decoder.enumDecoder(GroupType)
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/PackageId.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/PackageId.scala
@@ -9,6 +9,8 @@
 package com.advancedtelematic.ota.deviceregistry.data
 
 import cats.{Eq, Show}
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 
 final case class PackageId(name: PackageId.Name, version: PackageId.Version)
 
@@ -16,17 +18,15 @@ object PackageId {
   type Name    = String
   type Version = String
 
-  implicit val EncoderInstance = io.circe.generic.semiauto.deriveEncoder[PackageId]
-  implicit val DecoderInstance = io.circe.generic.semiauto.deriveDecoder[PackageId]
+  implicit val packageIdEncoder: Encoder[PackageId] = deriveEncoder[PackageId]
+  implicit val packageIdDecoder: Decoder[PackageId] = deriveDecoder[PackageId]
 
   /**
     * Use the underlying (string) ordering, show and equality for
     * package ids.
     */
-  implicit val PackageIdOrdering: Ordering[PackageId] = new Ordering[PackageId] {
-    override def compare(id1: PackageId, id2: PackageId): Int =
-      id1.name + id1.version compare id2.name + id2.version
-  }
+  implicit val PackageIdOrdering: Ordering[PackageId] =
+    (id1: PackageId, id2: PackageId) => id1.name + id1.version compare id2.name + id2.version
 
   implicit val showInstance: Show[PackageId] =
     Show.show(id => s"${id.name}-${id.version}")

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DbOps.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DbOps.scala
@@ -1,8 +1,7 @@
 package com.advancedtelematic.ota.deviceregistry.db
 
-import com.advancedtelematic.libats.slick.codecs.SlickRefined._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
-import com.advancedtelematic.ota.deviceregistry.data.Group._
+import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
 import com.advancedtelematic.ota.deviceregistry.data.SortBy
 import com.advancedtelematic.ota.deviceregistry.data.SortBy.SortBy
 import com.advancedtelematic.ota.deviceregistry.db.GroupInfoRepository.GroupInfoTable

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
@@ -22,7 +22,7 @@ import com.advancedtelematic.ota.deviceregistry.common.Errors
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, SearchParams}
 import com.advancedtelematic.ota.deviceregistry.data.Device._
 import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus.DeviceStatus
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.data._
 import com.advancedtelematic.ota.deviceregistry.db.DbOps.PaginationResultOps

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
@@ -18,10 +18,11 @@ import com.advancedtelematic.libats.slick.db.Operators.regex
 import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
 import com.advancedtelematic.ota.deviceregistry.common.Errors
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, SearchParams}
-import com.advancedtelematic.ota.deviceregistry.data.Device._
 import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus.DeviceStatus
+import com.advancedtelematic.ota.deviceregistry.data.DeviceType.DeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.data._

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/GroupMemberRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/GroupMemberRepository.scala
@@ -8,9 +8,9 @@
 
 package com.advancedtelematic.ota.deviceregistry.db
 
-import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.PaginationResult
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
@@ -18,6 +18,7 @@ import com.advancedtelematic.ota.deviceregistry.common.Errors
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.{Device, GroupExpressionAST, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.DbOps.PaginationResultOps
+import com.advancedtelematic.ota.deviceregistry.db.SlickMappings.groupTypeMapper
 import slick.jdbc.MySQLProfile.api._
 import slick.lifted.Tag
 

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
@@ -15,7 +15,7 @@ import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
 import com.advancedtelematic.libats.slick.db.SlickUrnMapper.correlationIdMapper
 import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceInstallationResult, EcuInstallationResult, InstallationStat}
-import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
+import com.advancedtelematic.ota.deviceregistry.data.DeviceOemId
 import com.advancedtelematic.ota.deviceregistry.db.DbOps.PaginationResultOps
 import io.circe.Json
 import slick.jdbc.MySQLProfile.api._

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/SlickMappings.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/SlickMappings.scala
@@ -11,10 +11,13 @@ package com.advancedtelematic.ota.deviceregistry.db
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.slick.codecs.SlickEnumMapper
 import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType
-import com.advancedtelematic.ota.deviceregistry.data.{CredentialsType, GroupType, PackageId}
+import com.advancedtelematic.ota.deviceregistry.data.{CredentialsType, DeviceType, GroupType, PackageId}
 import slick.jdbc.MySQLProfile.api._
 
 object SlickMappings {
+
+  implicit val deviceTypeMapper = SlickEnumMapper.enumMapper(DeviceType)
+
   implicit val groupTypeMapper = SlickEnumMapper.enumMapper(GroupType)
 
   implicit val credentialsTypeMapper = SlickEnumMapper.enumMapper(CredentialsType)

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeviceCreated.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeviceCreated.scala
@@ -12,8 +12,9 @@ import java.time.Instant
 
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.MessageLike
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceName, DeviceType}
+import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName
 
 final case class DeviceCreated(namespace: Namespace,
                                uuid: DeviceId,

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeviceCreated.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeviceCreated.scala
@@ -10,11 +10,15 @@ package com.advancedtelematic.ota.deviceregistry.messages
 
 import java.time.Instant
 
+import cats.syntax.show._
+import com.advancedtelematic.libats.codecs.CirceCodecs._
 import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.libats.messaging_datatype.MessageLike
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import com.advancedtelematic.ota.deviceregistry.data.DeviceName
+import com.advancedtelematic.libats.messaging_datatype.MessageLike
+import com.advancedtelematic.ota.deviceregistry.data.DeviceType.DeviceType
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, DeviceOemId}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 
 final case class DeviceCreated(namespace: Namespace,
                                uuid: DeviceId,
@@ -24,9 +28,7 @@ final case class DeviceCreated(namespace: Namespace,
                                timestamp: Instant = Instant.now())
 
 object DeviceCreated {
-  import cats.syntax.show._
-  import com.advancedtelematic.libats.codecs.CirceCodecs._
-  implicit val EncoderInstance     = io.circe.generic.semiauto.deriveEncoder[DeviceCreated]
-  implicit val DecoderInstance     = io.circe.generic.semiauto.deriveDecoder[DeviceCreated]
-  implicit val MessageLikeInstance = MessageLike[DeviceCreated](_.uuid.show)
+  implicit val deviceCreatedEncoder: Encoder[DeviceCreated] = deriveEncoder[DeviceCreated]
+  implicit val deviceCreatedDecoder: Decoder[DeviceCreated] = deriveDecoder[DeviceCreated]
+  implicit val deviceCreatedMessageLike: MessageLike[DeviceCreated] = MessageLike[DeviceCreated](_.uuid.show)
 }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -23,7 +23,7 @@ import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsL
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, UpdateDevice}
 import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.PackageId
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, PackageId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Regex

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -21,9 +21,9 @@ import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsLevel.InstallationStatsLevel
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, UpdateDevice}
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, PackageId}
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, GroupExpression, PackageId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Regex

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -23,7 +23,7 @@ import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsL
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, UpdateDevice}
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, GroupExpression, PackageId}
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, DeviceOemId, GroupExpression, PackageId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Regex

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
@@ -21,6 +21,7 @@ import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceSeen
 import com.advancedtelematic.ota.deviceregistry.common.{Errors, PackageStat}
 import com.advancedtelematic.ota.deviceregistry.daemon.{DeleteDeviceHandler, DeviceSeenListener}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId, ValidExpression}
 import com.advancedtelematic.ota.deviceregistry.data.{Device, DeviceStatus, PackageId, _}
 import com.advancedtelematic.ota.deviceregistry.db.InstalledPackages
@@ -466,8 +467,8 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
   }
 
   property("can search dynamic group devices") {
-    val deviceT1    = genDeviceTWith(Gen.const(refineMV[ValidDeviceName]("d1-xxyy-1234")), Gen.const(DeviceOemId("d1-xxyy-1234"))).generate
-    val deviceT2    = genDeviceTWith(Gen.const(refineMV[ValidDeviceName]("d2-xxyy-5678")), Gen.const(DeviceOemId("d2-xxyy-5678"))).generate
+    val deviceT1    = genDeviceTWith(Gen.const(validatedDeviceType.from("d1-xxyy-1234").right.get), Gen.const(DeviceOemId("d1-xxyy-1234"))).generate
+    val deviceT2    = genDeviceTWith(Gen.const(validatedDeviceType.from("d2-xxyy-5678").right.get), Gen.const(DeviceOemId("d2-xxyy-5678"))).generate
     val deviceUuid1 = createDeviceOk(deviceT1)
     val deviceUuid2 = createDeviceOk(deviceT2)
     createDynamicGroupOk(refineMV[ValidExpression]("deviceid contains xxyy"))
@@ -672,9 +673,9 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
 
   property("counts devices that satisfy a dynamic group expression") {
     val testDevices = Map(
-      Refined.unsafeApply[String, ValidDeviceName]("device1") -> DeviceOemId("abc123"),
-      Refined.unsafeApply[String, ValidDeviceName]("device2") -> DeviceOemId("123abc456"),
-      Refined.unsafeApply[String, ValidDeviceName]("device3") -> DeviceOemId("123aba456")
+      validatedDeviceType.from("device1").right.get -> DeviceOemId("abc123"),
+      validatedDeviceType.from("device2").right.get -> DeviceOemId("123abc456"),
+      validatedDeviceType.from("device3").right.get -> DeviceOemId("123aba456")
     )
     testDevices
       .map(t => (Gen.const(t._1), Gen.const(t._2)))

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
@@ -22,7 +22,7 @@ import com.advancedtelematic.ota.deviceregistry.common.{Errors, PackageStat}
 import com.advancedtelematic.ota.deviceregistry.daemon.{DeleteDeviceHandler, DeviceSeenListener}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
 import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId, ValidExpression}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.{Device, DeviceStatus, PackageId, _}
 import com.advancedtelematic.ota.deviceregistry.db.InstalledPackages
 import com.advancedtelematic.ota.deviceregistry.db.InstalledPackages.{DevicesCount, InstalledPackage}
@@ -68,7 +68,7 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
 
     deviceIds.take(4).foreach(addDeviceToGroupOk(staticGroup, _))
     val expr = deviceTs.slice(4, 8).map(_.deviceId.underlying.take(6)).map(n => s"deviceid contains $n").reduce(_ + " or " + _)
-    createDynamicGroupOk(Refined.unsafeApply(expr))
+    createDynamicGroupOk(GroupExpression(expr).right.get)
 
     Map("all" -> deviceIds, "groupedStatic" -> deviceIds.take(4),
       "groupedDynamic" -> deviceIds.slice(4, 8), "ungrouped" -> deviceIds.drop(8))
@@ -471,7 +471,7 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
     val deviceT2    = genDeviceTWith(Gen.const(validatedDeviceType.from("d2-xxyy-5678").right.get), Gen.const(DeviceOemId("d2-xxyy-5678"))).generate
     val deviceUuid1 = createDeviceOk(deviceT1)
     val deviceUuid2 = createDeviceOk(deviceT2)
-    createDynamicGroupOk(refineMV[ValidExpression]("deviceid contains xxyy"))
+    createDynamicGroupOk(GroupExpression("deviceid contains xxyy").right.get)
 
     val regex = refineMV[Regex]("1234")
     getDevicesByGrouping(grouped = true, GroupType.dynamic.some, regex.some) ~> route ~> check {
@@ -572,7 +572,7 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
   val listener = new DeleteDeviceHandler()
 
   property("DELETE device removes it from its group") {
-    forAll { (devicePre: DeviceT, groupName: Group.Name) =>
+    forAll { (devicePre: DeviceT, groupName: GroupName) =>
       val uuid = createDeviceOk(devicePre)
       val groupId    = createStaticGroupOk(groupName)
 
@@ -683,7 +683,7 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
       .map(_.sample.get)
       .map(createDeviceOk)
 
-    val expression: GroupExpression = Refined.unsafeApply("deviceid contains abc and deviceid position(5) is b and deviceid position(9) is 6")
+    val expression: GroupExpression = GroupExpression("deviceid contains abc and deviceid position(5) is b and deviceid position(9) is 6").right.get
     countDevicesForExpression(expression.some) ~> route ~> check {
       status shouldBe OK
       responseAs[Int] shouldBe 1
@@ -773,8 +773,8 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
 
   property("finds dynamic group devices only once") {
     val deviceUuid = createDeviceOk(genDeviceT.generate.copy(deviceId = DeviceOemId("abcd-1234")))
-    createDynamicGroupOk(refineMV[ValidExpression]("deviceid contains abcd"))
-    createDynamicGroupOk(refineMV[ValidExpression]("deviceid contains 1234"))
+    createDynamicGroupOk(GroupExpression("deviceid contains abcd").right.get)
+    createDynamicGroupOk(GroupExpression("deviceid contains 1234").right.get)
 
     getDevicesByGrouping(grouped = true, Some(GroupType.dynamic)) ~> route ~> check {
       status shouldBe OK
@@ -785,7 +785,7 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
 
   property("finds grouped devices only once") {
     val deviceUuid = createDeviceOk(genDeviceT.generate.copy(deviceId = DeviceOemId("abcd")))
-    createDynamicGroupOk(refineMV[ValidExpression]("deviceid contains abcd"))
+    createDynamicGroupOk(GroupExpression("deviceid contains abcd").right.get)
     val group = createStaticGroupOk()
     addDeviceToGroupOk(group, deviceUuid)
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
@@ -20,7 +20,8 @@ import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceSeen
 import com.advancedtelematic.ota.deviceregistry.common.{Errors, PackageStat}
 import com.advancedtelematic.ota.deviceregistry.daemon.{DeleteDeviceHandler, DeviceSeenListener}
-import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.Codecs.activeDeviceCountDecoder
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{ActiveDeviceCount, DeviceT}
 import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.{Device, DeviceStatus, PackageId, _}
@@ -67,7 +68,7 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
     val staticGroup = createStaticGroupOk()
 
     deviceIds.take(4).foreach(addDeviceToGroupOk(staticGroup, _))
-    val expr = deviceTs.slice(4, 8).map(_.deviceId.underlying.take(6)).map(n => s"deviceid contains $n").reduce(_ + " or " + _)
+    val expr = deviceTs.slice(4, 8).map(_.deviceId.value.take(6)).map(n => s"deviceid contains $n").reduce(_ + " or " + _)
     createDynamicGroupOk(GroupExpression(expr).right.get)
 
     Map("all" -> deviceIds, "groupedStatic" -> deviceIds.take(4),

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
@@ -7,31 +7,24 @@ import com.advancedtelematic.libats.data.{ErrorCodes, ErrorRepresentation, Pagin
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, ValidExpression, _}
-import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupType}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
+import com.advancedtelematic.ota.deviceregistry.data.{GroupExpression, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.refineV
-import io.circe.Decoder
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.SpanSugar._
 
 class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventually {
 
-  import com.advancedtelematic.libats.codecs.CirceCodecs._
-  import io.circe.generic.semiauto.deriveDecoder
-
-  private[this] implicit val GroupDecoder: Decoder[Group] = deriveDecoder[Group]
-
   implicit class DeviceIdToExpression(value: DeviceOemId) {
     def toValidExp: GroupExpression =
-      refineV[ValidExpression](s"deviceid contains ${value.underlying}").valueOr(err => throw new IllegalArgumentException(err))
+      GroupExpression(s"deviceid contains ${value.underlying}").valueOr(err => throw new IllegalArgumentException(err))
   }
 
   test("dynamic group gets created.") {
-    createGroup(GroupType.dynamic, Some(Refined.unsafeApply("deviceid contains something")), None) ~> route ~> check {
+    createGroup(GroupType.dynamic, Some(GroupExpression("deviceid contains something").right.get), None) ~> route ~> check {
       status shouldBe Created
     }
   }
@@ -50,7 +43,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("dynamic group is empty when no device matches the expression") {
-    val groupId    = createDynamicGroupOk(Refined.unsafeApply("deviceid contains nothing"))
+    val groupId    = createDynamicGroupOk(GroupExpression("deviceid contains nothing").right.get)
 
     listDevicesInGroup(groupId) ~> route ~> check {
       status shouldBe OK
@@ -60,7 +53,15 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("dynamic group with invalid expression is not created") {
-    createGroup(GroupType.dynamic, Some(Refined.unsafeApply("")), None) ~> route ~> check {
+    val body = io.circe.parser.parse(
+      """
+        | {
+        |   "name"       : "some name",
+        |   "groupType"  : "dynamic",
+        |   "expression" : ""
+        | }
+      """.stripMargin).valueOr(throw _)
+    createGroup(body) ~> route ~> check {
       status shouldBe BadRequest
       responseAs[ErrorRepresentation].code shouldBe ErrorCodes.InvalidEntity
     }
@@ -121,9 +122,9 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
-    val expression1 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceId.show.substring(0, 5)}") // To test "starts with"
+    val expression1 = GroupExpression(s"deviceid contains ${deviceId.show.substring(0, 5)}").right.get // To test "starts with"
     val groupId1    = createDynamicGroupOk(expression1)
-    val expression2 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceId.show.substring(2, 10)}") // To test "contains"
+    val expression2 = GroupExpression(s"deviceid contains ${deviceId.show.substring(2, 10)}").right.get // To test "contains"
     val groupId2    = createDynamicGroupOk(expression2)
 
     getGroupsOfDevice(deviceUuid) ~> route ~> check {
@@ -140,9 +141,9 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
-    val expression1 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceId.show.substring(0, 3)} and deviceid contains ${deviceId.show.substring(6, 9)}")
+    val expression1 = GroupExpression(s"deviceid contains ${deviceId.show.substring(0, 3)} and deviceid contains ${deviceId.show.substring(6, 9)}").right.get
     val groupId1    = createDynamicGroupOk(expression1)
-    val expression2 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains 0empty0")
+    val expression2 = GroupExpression(s"deviceid contains 0empty0").right.get
     val _    = createDynamicGroupOk(expression2)
 
     getGroupsOfDevice(deviceUuid) ~> route ~> check {
@@ -162,7 +163,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
     addDeviceToGroupOk(staticGroupId, deviceUuid)
 
     // Make the device show up for a dynamic group
-    val expression = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceT.deviceId.show.substring(1, 5)}")
+    val expression = GroupExpression(s"deviceid contains ${deviceT.deviceId.show.substring(1, 5)}").right.get
     val dynamicGroupId = createDynamicGroupOk(expression)
 
     getGroupsOfDevice(deviceUuid) ~> route ~> check {

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
@@ -6,6 +6,7 @@ import cats.syntax.show._
 import com.advancedtelematic.libats.data.{ErrorCodes, ErrorRepresentation, PaginationResult}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, ValidExpression, _}
 import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
@@ -116,7 +117,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device returns the correct dynamic groups") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("12347890800808"))
+    val deviceT = genDeviceT.sample.get.copy(deviceName = validatedDeviceType.from("12347890800808").right.get)
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
@@ -135,7 +136,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device using two 'contains' returns the correct dynamic groups") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("ABCDEFGHIJ"))
+    val deviceT = genDeviceT.sample.get.copy(deviceName = validatedDeviceType.from("ABCDEFGHIJ").right.get)
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
@@ -153,7 +154,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device returns the correct groups (dynamic and static)") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("ABCDE"))
+    val deviceT = genDeviceT.sample.get.copy(deviceName = validatedDeviceType.from("ABCDE").right.get)
     val deviceUuid = createDeviceOk(deviceT)
 
     // Add the device to a static group

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
@@ -5,10 +5,9 @@ import cats.syntax.either._
 import cats.syntax.show._
 import com.advancedtelematic.libats.data.{ErrorCodes, ErrorRepresentation, PaginationResult}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
-import com.advancedtelematic.ota.deviceregistry.data.{GroupExpression, GroupType}
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceOemId, GroupExpression, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import eu.timepit.refined.api.Refined
@@ -20,7 +19,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
 
   implicit class DeviceIdToExpression(value: DeviceOemId) {
     def toValidExp: GroupExpression =
-      GroupExpression(s"deviceid contains ${value.underlying}").valueOr(err => throw new IllegalArgumentException(err))
+      GroupExpression(s"deviceid contains ${value.value}").valueOr(err => throw new IllegalArgumentException(err))
   }
 
   test("dynamic group gets created.") {

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupRequests.scala
@@ -13,6 +13,8 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.Uri.Query
 import cats.syntax.show._
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.data.Codecs.createGroupEncoder
+import com.advancedtelematic.ota.deviceregistry.data.DataType.CreateGroup
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId._
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsRequests.scala
@@ -11,13 +11,13 @@ package com.advancedtelematic.ota.deviceregistry
 import java.util.Base64
 
 import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
-import com.advancedtelematic.libats.data.ValidationError
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.PublicCredentialsResource.FetchPublicCredentials
 import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.CredentialsType.CredentialsType
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
 import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceOemId, DeviceType}
 
 import scala.concurrent.ExecutionContext
 
@@ -49,7 +49,7 @@ trait PublicCredentialsRequests { self: ResourceSpec =>
 
   def updatePublicCredentials(device: DeviceOemId, creds: Array[Byte], cType: Option[CredentialsType])
                              (implicit ec: ExecutionContext): HttpRequest = {
-    val devT = validatedDeviceType.from(device.underlying)
+    val devT = validatedDeviceType.from(device.value)
       .map(DeviceT(None, _, device, DeviceType.Other, Some(base64Encoder.encodeToString(creds)), cType))
     createDeviceWithCredentials(devT.right.get)
   }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/PublicCredentialsResourceSpec.scala
@@ -9,7 +9,7 @@
 package com.advancedtelematic.ota.deviceregistry
 
 import akka.http.scaladsl.model.StatusCodes._
-import com.advancedtelematic.ota.deviceregistry.data.{CredentialsType, Device}
+import com.advancedtelematic.ota.deviceregistry.data.{CredentialsType, Device, DeviceOemId}
 import com.advancedtelematic.ota.deviceregistry.PublicCredentialsResource.FetchPublicCredentials
 import io.circe.generic.auto._
 import org.scalacheck.{Arbitrary, Gen}

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
@@ -8,13 +8,13 @@
 
 package com.advancedtelematic.ota.deviceregistry.data
 
-import eu.timepit.refined.api.Refined
-import org.scalacheck.{Arbitrary, Gen}
 import java.time.Instant
 
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Namespaces.defaultNs
+import org.scalacheck.{Arbitrary, Gen}
 
 trait DeviceGenerators {
 
@@ -25,7 +25,7 @@ trait DeviceGenerators {
     //use a minimum length for DeviceName to reduce possibility of naming conflicts
     size <- Gen.choose(10, 100)
     name <- Gen.containerOfN[Seq, Char](size, Gen.alphaNumChar)
-  } yield Refined.unsafeApply(name.mkString)
+  } yield validatedDeviceType.from(name.mkString).right.get
 
   val genDeviceUUID: Gen[DeviceId] = Gen.delay(DeviceId.generate)
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
@@ -13,6 +13,7 @@ import java.time.Instant
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
 import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
+import com.advancedtelematic.ota.deviceregistry.data.DeviceType.DeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Namespaces.defaultNs
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceIdGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceIdGenerators.scala
@@ -9,7 +9,6 @@
 package com.advancedtelematic.ota.deviceregistry.data
 
 import cats.syntax.show._
-import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import org.scalacheck.{Arbitrary, Gen}
 
 /**
@@ -55,7 +54,7 @@ trait DeviceIdGenerators {
 
     Gen
       .oneOf(genTooLongVin, genTooShortVin, genNotAlphaNumVin)
-      .map(DeviceOemId)
+      .map(DeviceOemId.apply)
   }
 
   def getInvalidVin: DeviceOemId =

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParserSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParserSpec.scala
@@ -6,7 +6,6 @@ import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.http.Errors
 import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.test.DatabaseSpec
-import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import com.advancedtelematic.ota.deviceregistry.data.GroupExpressionAST.{And, DeviceIdCharAt, DeviceIdContains, Or}
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository.DeviceTable

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupGenerators.scala
@@ -10,22 +10,21 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
-import eu.timepit.refined.api.Refined
 import org.scalacheck.{Arbitrary, Gen}
 
 trait GroupGenerators {
 
   private lazy val defaultNs: Namespace = Namespace("default")
 
-  def genGroupName(charGen: Gen[Char] = Arbitrary.arbChar.arbitrary): Gen[Group.Name] = for {
+  def genGroupName(charGen: Gen[Char] = Arbitrary.arbChar.arbitrary): Gen[GroupName] = for {
     strLen <- Gen.choose(2, 100)
     name   <- Gen.listOfN[Char](strLen, charGen)
-  } yield Refined.unsafeApply(name.mkString)
+  } yield GroupName(name.mkString).right.get
 
   def genStaticGroup: Gen[Group] =
     genGroupName().flatMap(Group(GroupId.generate(), _, defaultNs, GroupType.static, None))
 
-  implicit lazy val arbGroupName: Arbitrary[Group.Name] = Arbitrary(genGroupName())
+  implicit lazy val arbGroupName: Arbitrary[GroupName] = Arbitrary(genGroupName())
   implicit lazy val arbStaticGroup: Arbitrary[Group] = Arbitrary(genStaticGroup)
 }
 


### PR DESCRIPTION
I started by moving away from `Refined` to use our new `ValidatedGeneric` but it ended up as a bigger refactor. What this PR mainly does:

- Use `ValidatedGeneric` instead of `Refined` for `DeviceName`.
- Use `ValidatedGeneric` instead of `Refined` for `GroupName` (previously `Group.Name`).
- Use `ValidatedGeneric` instead of `Refined` for `GroupExpression`.
- Save `DeviceType` as a `String` in the DB instead of as `Int`s (and migrate the `Int`s).
- Bundle most Marshallers in a dedicated object.
- Rename and move codecs for consistency.
- Extract enumerations to its own files.
- Other minor tidying up.
