### PR TITLE
Don't use latest version of openjdk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,8 +99,8 @@ lazy val dockerSettings = Seq(
   dockerRepository := Some("advancedtelematic"),
   packageName := packageName.value,
   dockerUpdateLatest := true,
+  dockerBaseImage := "advancedtelematic/alpine-jre:8",
   dockerCommands ++= Seq(
-    Cmd("FROM", "advancedtelematic/alpine-jre:8u191-jre-alpine3.9"),
     Cmd("USER", "root"),
     Cmd("USER", (daemonUser in Docker).value)
   )


### PR DESCRIPTION
The tag `8u191-jre-alpine3.9` was throwing the same error as before. Tag `8` does the trick.