### PR TITLE
[OTA-2308] Extend the CSV export endpoint to accept multiple correlationIds

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -204,8 +204,8 @@ class DevicesResource(
     complete(db.run(action))
   }
 
-  def fetchFailureStats(correlationId: CorrelationId, failureCode: Option[String]): Route = {
-    val f = db.run(InstallationReportRepository.fetchDeviceFailures(correlationId, failureCode))
+  def fetchFailureStats(correlationIds: Iterable[CorrelationId], failureCode: Option[String]): Route = {
+    val f = db.run(InstallationReportRepository.fetchDeviceFailures(correlationIds.toSet, failureCode))
     onSuccess(f) { s =>
       respondWithHeader(`Content-Type`(ContentTypes.`text/csv(UTF-8)`)) {
         complete(s)
@@ -224,7 +224,7 @@ class DevicesResource(
           case None      => complete(Errors.InvalidGroupExpression(""))
           case Some(exp) => countDynamicGroupCandidates(ns.namespace, exp)
         } ~
-        (path("failed-installations.csv") & parameters('correlationId.as[CorrelationId], 'failureCode.as[String].?)) {
+        (path("failed-installations.csv") & parameters('correlationId.as[CorrelationId].*, 'failureCode.as[String].?)) {
           (cid, fc) => fetchFailureStats(cid, fc)
         } ~
         (path("stats") & parameters('correlationId.as[CorrelationId], 'reportLevel.as[InstallationStatsLevel].?)) {

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
@@ -128,10 +128,10 @@ object InstallationReportRepository {
       .map(_.installationReport)
       .paginateResult(offset.orDefaultOffset, limit.orDefaultLimit)
 
-  def fetchDeviceFailures(correlationId: CorrelationId, failureCode: Option[String])
+  def fetchDeviceFailures(correlationIds: Set[CorrelationId], failureCode: Option[String])
                          (implicit ec: ExecutionContext): DBIO[Seq[(DeviceOemId, String, String)]] =
       deviceInstallationResults
-        .filter(_.correlationId === correlationId)
+        .filter(_.correlationId inSet correlationIds)
         .filter(_.success === false)
         .maybeFilter(_.resultCode === failureCode)
         .join(DeviceRepository.devices)

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -182,8 +182,8 @@ trait DeviceRequests { self: ResourceSpec =>
   def getStats(correlationId: CorrelationId, level: InstallationStatsLevel): HttpRequest =
     Get(Resource.uri(api, "stats").withQuery(Query("correlationId" -> correlationId.toString, "level" -> level.toString)))
 
-  def getFailedExport(correlationId: CorrelationId, failureCode: Option[String]): HttpRequest = {
-    val m = Map("correlationId" -> correlationId.toString)
+  def getFailedExport(failureCode: Option[String], correlationIds: CorrelationId*): HttpRequest = {
+    val m = correlationIds.map("correlationId" -> _.toString).toMap
     val params = failureCode.fold(m)(fc => m + ("failureCode" -> fc))
     Get(Resource.uri(api, "failed-installations.csv").withQuery(Query(params)))
   }


### PR DESCRIPTION
We need to update the CSV export to take into account the new retry-campaigns. Therefore the export endpoint now accepts multiple `correlationId`s to pass the main-campaign ID and the retry-campaign ID.