### PR TITLE
Make the installation reports migration from auditor optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Management of device status and configuration information. This project is part 
 
 ## Building
 
+You will have to set the environment variable `AUDITOR_MIGRATE=false` before running this service as part of the Community Edition.
+
 `sbt docker:publishLocal` - to publish docker image locally.  
 
 ## Running tests

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -35,6 +35,8 @@ auditor = {
   port = 8086
   port = ${?AUDITOR_PORT}
   uri = "http://"${auditor.host}":"${auditor.port}
+  migrate = true
+  migrate = ${?AUDITOR_MIGRATE}
 }
 
 main {

--- a/src/main/scala/db/migration/R__AuditorInstallationReportsMigration.scala
+++ b/src/main/scala/db/migration/R__AuditorInstallationReportsMigration.scala
@@ -1,12 +1,13 @@
 package db.migration
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.advancedtelematic.libats.http.ServiceHttpClientSupport
 import com.advancedtelematic.libats.slick.db.AppMigration
 import com.advancedtelematic.ota.deviceregistry.client.AuditorHttpClient
 import com.advancedtelematic.ota.deviceregistry.db.MigrateOldInstallationReports
-import com.typesafe.config.ConfigFactory
-import slick.jdbc.MySQLProfile
+import com.typesafe.config.{Config, ConfigFactory}
+import slick.jdbc.MySQLProfile.api.Database
 
 import scala.concurrent.Future
 
@@ -16,9 +17,14 @@ class R__AuditorInstallationReportsMigration extends AppMigration with ServiceHt
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
-  private val auditorUri = ConfigFactory.load().getString("auditor.uri")
+  private val config: Config = ConfigFactory.load()
+  private val migrateAuditor = config.getBoolean("auditor.migrate")
+  private val auditorUri = config.getString("auditor.uri")
   private val auditor = new AuditorHttpClient(auditorUri, defaultHttpClient)
 
-  override def migrate(implicit db: MySQLProfile.api.Database): Future[Unit] =
-    new MigrateOldInstallationReports(auditor).run.map(_ => ())
+  override def migrate(implicit db: Database): Future[Unit] =
+    if (migrateAuditor)
+      new MigrateOldInstallationReports(auditor).run.map(_ => ())
+    else
+      Future.unit
 }


### PR DESCRIPTION
Fixes #84.
This is to support the OTA Community Edition. Since the auditor is not a public service, we need to offer the possibility to make the installation reports migration optional. Otherwise it will always fail for users of the Community Edition.