### PR TITLE
Bump libats version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val library =
     object Version {
       val scalaCheck = "1.13.5"
       val scalaTest  = "3.0.4"
-      val libAts     = "0.2.1-2-g962e326"
+      val libAts     = "0.2.1-13-g4a34692"
       val akkaHttp = "10.0.10"
       val mariaDb = "1.4.4"
       val circe = "0.9.1"

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
@@ -1,6 +1,7 @@
 package com.advancedtelematic.ota.deviceregistry.data
 
 import io.circe.{Decoder, Encoder}
+import com.advancedtelematic.libats.codecs.CirceAnyVal.{anyValStringEncoder, anyValStringDecoder}
 import com.advancedtelematic.libats.codecs.CirceCodecs.{refinedDecoder, refinedEncoder}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStat, UpdateDevice}
 

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CsvSerializer.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/CsvSerializer.scala
@@ -2,6 +2,7 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import cats.Show
 import cats.syntax.show._
+import com.advancedtelematic.libats.data.DataType.{ResultCode, ResultDescription}
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 
 trait CsvSerializer[T] {
@@ -13,11 +14,13 @@ object CsvSerializer {
   val recordSeparator = "\n"
 
   implicit val showString: Show[String] = identity _
+  implicit val showResultCode: Show[ResultCode] = _.value
+  implicit val showResultDescription: Show[ResultDescription] = _.value
 
   implicit def tuple3Serializer[A: Show, B: Show, C: Show]: CsvSerializer[(A, B, C)] =
     (t: (A, B, C)) => t._1.show +: t._2.show +: t._3.show +: Nil
 
-  implicit val deviceIdFailureSerializer = implicitly[CsvSerializer[(DeviceOemId, String, String)]]
+  implicit val deviceIdFailureSerializer = implicitly[CsvSerializer[(DeviceOemId, ResultCode, ResultDescription)]]
 
   def asCsv[T](header: Seq[String], rows: Seq[T])(implicit serializer: CsvSerializer[T]): String = {
     val head = header.mkString(fieldSeparator)

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.ota.deviceregistry.data
 import java.time.Instant
 
 import cats.Show
-import com.advancedtelematic.libats.data.DataType.CorrelationId
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, ResultCode}
 import com.advancedtelematic.libats.data.EcuIdentifier
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, Event}
 import com.advancedtelematic.ota.deviceregistry.data.CredentialsType.CredentialsType
@@ -18,7 +18,7 @@ import io.circe.Json
 object DataType {
   case class IndexedEvent(device: DeviceId, eventID: String, eventType: IndexedEventType, correlationId: Option[CorrelationId])
 
-  case class InstallationStat(resultCode: String, total: Int, success: Boolean)
+  case class InstallationStat(resultCode: ResultCode, total: Int, success: Boolean)
 
   object IndexedEventType extends Enumeration {
     type IndexedEventType = Value
@@ -45,8 +45,8 @@ object DataType {
     s"(device=${event.deviceUuid},eventId=${event.eventId},eventType=${event.eventType})"
   }
 
-  final case class DeviceInstallationResult(correlationId: CorrelationId, resultCode: String, deviceId: DeviceId, success: Boolean, receivedAt: Instant, installationReport: Json)
-  final case class EcuInstallationResult(correlationId: CorrelationId, resultCode: String, deviceId: DeviceId, ecuId: EcuIdentifier, success: Boolean)
+  final case class DeviceInstallationResult(correlationId: CorrelationId, resultCode: ResultCode, deviceId: DeviceId, success: Boolean, receivedAt: Instant, installationReport: Json)
+  final case class EcuInstallationResult(correlationId: CorrelationId, resultCode: ResultCode, deviceId: DeviceId, ecuId: EcuIdentifier, success: Boolean)
 
   final case class SearchParams(oemId: Option[DeviceOemId], grouped: Option[Boolean], groupType: Option[GroupType],
                           groupId: Option[GroupId], regex: Option[String Refined Regex], offset: Option[Long], limit: Option[Long]) {

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateOldInstallationReports.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateOldInstallationReports.scala
@@ -2,7 +2,7 @@ package com.advancedtelematic.ota.deviceregistry.db
 import akka.Done
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
-import com.advancedtelematic.libats.data.DataType.MultiTargetUpdateId
+import com.advancedtelematic.libats.data.DataType.{MultiTargetUpdateId, ResultCode, ResultDescription}
 import com.advancedtelematic.libats.messaging_datatype.DataType.{EcuInstallationReport, InstallationResult, OperationResult}
 import com.advancedtelematic.libats.messaging_datatype.MessageCodecs.deviceInstallationReportEncoder
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceInstallationReport
@@ -29,13 +29,13 @@ class MigrateOldInstallationReports(auditor: AuditorClient)(implicit db: Databas
   def toNewSchema(oldReport: DeviceUpdateReport): DeviceInstallationReport = {
 
     def toResultObject(resultCode: Int): InstallationResult = resultCode match {
-      case 0 => InstallationResult(success = true, "0", "All targeted ECUs were successfully updated")
-      case _ => InstallationResult(success = false, "19", "One or more targeted ECUs failed to update")
+      case 0 => InstallationResult(success = true, ResultCode("0"), ResultDescription("All targeted ECUs were successfully updated"))
+      case _ => InstallationResult(success = false, ResultCode("19"), ResultDescription("One or more targeted ECUs failed to update"))
     }
 
     def toEcuInstallationReport(or: OperationResult): EcuInstallationReport =
       EcuInstallationReport(
-        InstallationResult(or.resultCode == 0 || or.resultCode == 1, or.resultCode.toString, or.resultText),
+        InstallationResult(or.resultCode == 0 || or.resultCode == 1, ResultCode(or.resultCode.toString), ResultDescription(or.resultText)),
         Seq(or.target.value),
         None)
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeviceInstallationReportListenerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeviceInstallationReportListenerSpec.scala
@@ -1,6 +1,7 @@
 package com.advancedtelematic.ota.deviceregistry.daemon
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.advancedtelematic.libats.data.DataType.ResultCode
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.MessageCodecs.deviceUpdateCompletedEncoder
 import com.advancedtelematic.libats.test.DatabaseSpec
@@ -12,7 +13,7 @@ import com.advancedtelematic.ota.deviceregistry.ResourcePropSpec
 import io.circe.syntax._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.Matchers
 
 class DeviceUpdateEventListenerSpec
     extends ResourcePropSpec
@@ -31,7 +32,7 @@ class DeviceUpdateEventListenerSpec
   property("should parse and save DeviceUpdateReport messages and is idempotent") {
     val deviceUuid = createDeviceOk(genDeviceT.generate)
     val correlationId = genCorrelationId.generate
-    val message = genDeviceInstallationReport(correlationId, "0", deviceUuid).generate
+    val message = genDeviceInstallationReport(correlationId, ResultCode("0"), deviceUuid).generate
 
     listener.apply(message).futureValue shouldBe (())
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateOldInstallationReportsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateOldInstallationReportsSpec.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import cats.syntax.either._
 import com.advancedtelematic.libats.data.DataType.HashMethod.HashMethod
-import com.advancedtelematic.libats.data.DataType.{HashMethod, MultiTargetUpdateId, Namespace, ValidChecksum}
+import com.advancedtelematic.libats.data.DataType.{HashMethod, MultiTargetUpdateId, Namespace, ResultCode, ResultDescription, ValidChecksum}
 import com.advancedtelematic.libats.data.EcuIdentifier
 import com.advancedtelematic.libats.data.EcuIdentifier.validatedEcuIdentifier
 import com.advancedtelematic.libats.messaging_datatype.DataType._
@@ -100,15 +100,15 @@ class MigrateOldInstallationReportsSpec
       Namespace("migration-test"),
       DeviceId(UUID.fromString("88888888-4444-4444-4444-CCCCCCCCCCCC")),
       MultiTargetUpdateId(UUID.fromString("99999999-5555-5555-5555-DDDDDDDDDDDD")),
-      InstallationResult(success = false, "19", "One or more targeted ECUs failed to update"),
+      InstallationResult(success = false, ResultCode("19"), ResultDescription("One or more targeted ECUs failed to update")),
       Map(
         validatedEcuIdentifier.from("1234abcd").right.get -> EcuInstallationReport(
-          InstallationResult(success = true, "0", "All good."),
+          InstallationResult(success = true, ResultCode("0"), ResultDescription("All good.")),
           Seq("the-target-file"),
           None
         ),
         validatedEcuIdentifier.from("3456cdef").right.get -> EcuInstallationReport(
-          InstallationResult(success = false, "2", "Something went wrong."),
+          InstallationResult(success = false, ResultCode("2"), ResultDescription("Something went wrong.")),
           Seq("the-other-target-file"),
           None
         )


### PR DESCRIPTION
Necessary after advancedtelematic/libats#100.
Use libats `ResultCode` and `ResultDescription` value classes for installation results.