### PR TITLE
Make search device by name case insensitive

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -102,7 +102,7 @@ class DevicesResource(
       'grouped.as[Boolean].?,
       'groupType.as[GroupType].?,
       'groupId.as[GroupId].?,
-      'regex.as[String Refined Regex].?,
+      'nameContains.as[String].?,
       'offset.as[Long].?,
       'limit.as[Long].?)).as(SearchParams)
     { params => complete(db.run(DeviceRepository.search(ns, params))) }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -11,8 +11,6 @@ import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType.I
 import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceName, DeviceOemId, DeviceType}
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.string.Regex
 import io.circe.Json
 
 object DataType {
@@ -49,10 +47,10 @@ object DataType {
   final case class EcuInstallationResult(correlationId: CorrelationId, resultCode: ResultCode, deviceId: DeviceId, ecuId: EcuIdentifier, success: Boolean)
 
   final case class SearchParams(oemId: Option[DeviceOemId], grouped: Option[Boolean], groupType: Option[GroupType],
-                          groupId: Option[GroupId], regex: Option[String Refined Regex], offset: Option[Long], limit: Option[Long]) {
+                          groupId: Option[GroupId], nameContains: Option[String], offset: Option[Long], limit: Option[Long]) {
     if (oemId.isDefined) {
       require(groupId.isEmpty, "Invalid parameters: groupId must be empty when searching by deviceId.")
-      require(regex.isEmpty, "Invalid parameters: regex must be empty when searching by deviceId.")
+      require(nameContains.isEmpty, "Invalid parameters: nameContains must be empty when searching by deviceId.")
     }
   }
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
@@ -122,7 +122,12 @@ object DeviceRepository {
 
     devices
       .filter(_.namespace === ns)
-      .maybeContains(_.deviceName, nameContains)
+      .filter { device =>
+        nameContains match {
+          case None => true.bind
+          case Some(s) => device.deviceName.mappedTo[String].toLowerCase.like(s"%${s.toLowerCase}%")
+        }
+      }
       .filter(_.uuid in devicesInGroup)
   }
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -65,8 +65,8 @@ trait DeviceRequests { self: ResourceSpec =>
         .withQuery(Query("regex" -> regex, "offset" -> offset.toString, "limit" -> limit.toString))
     )
 
-  def fetchByDeviceId(deviceId: DeviceOemId, regex: Option[String] = None, groupId: Option[GroupId] = None): HttpRequest = {
-    val m = regex.map("regex" -> _).toMap ++ groupId.map("groupId" -> _.show).toMap + ("deviceId" -> deviceId.show)
+  def fetchByDeviceId(deviceId: DeviceOemId, nameContains: Option[String] = None, groupId: Option[GroupId] = None): HttpRequest = {
+    val m = nameContains.map("nameContains" -> _).toMap ++ groupId.map("groupId" -> _.show).toMap + ("deviceId" -> deviceId.show)
     Get(Resource.uri(api).withQuery(Query(m)))
   }
 
@@ -173,9 +173,9 @@ trait DeviceRequests { self: ResourceSpec =>
   def getGroupsOfDevice(deviceUuid: DeviceId): HttpRequest = Get(Resource.uri(api, deviceUuid.show, "groups"))
 
   def getDevicesByGrouping(grouped: Boolean, groupType: Option[GroupType],
-                           regex: Option[String Refined Regex] = None, limit: Long = 1000): HttpRequest = {
+                           nameContains: Option[String] = None, limit: Long = 1000): HttpRequest = {
     val m = Map("grouped" -> grouped, "limit" -> limit) ++
-      List("groupType" -> groupType, "regex" -> regex).collect { case (k, Some(v)) => k -> v }.toMap
+      List("groupType" -> groupType, "nameContains" -> nameContains).collect { case (k, Some(v)) => k -> v }.toMap
     Get(Resource.uri(api).withQuery(Query(m.mapValues(_.toString))))
   }
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
@@ -375,13 +375,13 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
     }
   }
 
-  property("searching a device by 'regex' and 'deviceId' fails") {
+  property("searching a device by 'nameContains' and 'deviceId' fails") {
     val deviceT = genDeviceT.sample.get
     createDeviceOk(deviceT)
 
     fetchByDeviceId(deviceT.deviceId, Some(""), None) ~> route ~> check {
       status shouldBe BadRequest
-      responseAs[ErrorRepresentation].description should include ("regex must be empty when searching by deviceId")
+      responseAs[ErrorRepresentation].description should include ("nameContains must be empty when searching by deviceId")
     }
   }
 
@@ -456,8 +456,8 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
     addDeviceToGroupOk(group, deviceUuid1)
     addDeviceToGroupOk(group, deviceUuid2)
 
-    val regex = Refined.unsafeApply[String, Regex](deviceT.deviceName.value.substring(0, 10))
-    getDevicesByGrouping(grouped = true, GroupType.static.some, regex.some) ~> route ~> check {
+    val nameContains = deviceT.deviceName.value.substring(0, 10)
+    getDevicesByGrouping(grouped = true, GroupType.static.some, nameContains.some) ~> route ~> check {
       status shouldBe OK
       val result = responseAs[PaginationResult[Device]].values.map(_.uuid)
       result should contain(deviceUuid1)
@@ -472,8 +472,8 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
     val deviceUuid2 = createDeviceOk(deviceT2)
     createDynamicGroupOk(refineMV[ValidExpression]("deviceid contains xxyy"))
 
-    val regex = refineMV[Regex]("1234")
-    getDevicesByGrouping(grouped = true, GroupType.dynamic.some, regex.some) ~> route ~> check {
+    val nameContains = "1234"
+    getDevicesByGrouping(grouped = true, GroupType.dynamic.some, nameContains.some) ~> route ~> check {
       status shouldBe OK
       val result = responseAs[PaginationResult[Device]].values.map(_.uuid)
       result should contain(deviceUuid1)
@@ -489,7 +489,7 @@ class DeviceResourceSpec extends ResourcePropSpec with ScalaFutures with Eventua
     val deviceTs             = genConflictFreeDeviceTs(limit * 2).generate
     val deviceIds = deviceTs.map(createDeviceOk)
 
-    // the database is case-insensitve so when we need to take that in to account when sorting in scala
+    // the database is case-insensitive so when we need to take that in to account when sorting in scala
     // furthermore PackageId is not lexicographically ordered so we just use pairs
     def canonPkg(pkg: PackageId) =
       (pkg.name.toLowerCase, pkg.version)


### PR DESCRIPTION
- Use `nameContains` to search devices by name instead of a regex.
- The search is now case-insensitive.