### PR TITLE
Stop using `Refined`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val library =
     object Version {
       val scalaCheck = "1.13.5"
       val scalaTest  = "3.0.4"
-      val libAts     = "0.2.1-13-g4a34692"
+      val libAts     = "0.3.0-8-gbef7cd7"
       val akkaHttp = "10.0.10"
       val mariaDb = "1.4.4"
       val circe = "0.9.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.7
+sbt.version = 1.2.8

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -38,8 +38,6 @@ import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.data.{GroupExpression, PackageId}
 import com.advancedtelematic.ota.deviceregistry.db._
 import com.advancedtelematic.ota.deviceregistry.messages.{DeleteDeviceRequest, DeviceCreated}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.string.Regex
 import io.circe.Json
 import slick.jdbc.MySQLProfile.api._
 
@@ -71,7 +69,6 @@ class DevicesResource(
   import Directives._
   import StatusCodes._
   import com.advancedtelematic.libats.http.AnyvalMarshallingSupport._
-  import com.advancedtelematic.libats.http.RefinedMarshallingSupport._
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 
   val extractPackageId: Directive1[PackageId] =
@@ -153,8 +150,8 @@ class DevicesResource(
     complete(db.run(InstalledPackages.getDevicesCount(pkg, ns)))
 
   def listPackagesOnDevice(device: DeviceId): Route =
-    parameters(('regex.as[String Refined Regex].?, 'offset.as[Long].?, 'limit.as[Long].?)) { (regex, offset, limit) =>
-      complete(db.run(InstalledPackages.installedOn(device, regex, offset, limit)))
+    parameters(('nameContains.as[String].?, 'offset.as[Long].?, 'limit.as[Long].?)) { (nameContains, offset, limit) =>
+      complete(db.run(InstalledPackages.installedOn(device, nameContains, offset, limit)))
     }
 
   implicit def offsetDateTimeUnmarshaller: FromStringUnmarshaller[OffsetDateTime] =

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -21,6 +21,7 @@ import cats.syntax.show._
 import com.advancedtelematic.libats.auth.{AuthedNamespaceScope, Scopes}
 import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace, ResultCode}
 import com.advancedtelematic.libats.http.UUIDKeyAkka._
+import com.advancedtelematic.libats.http.ValidatedGenericMarshalling.validatedStringUnmarshaller
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId._
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, Event, EventType}
@@ -32,9 +33,9 @@ import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsLevel.InstallationStatsLevel
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStatsLevel, SearchParams, UpdateDevice}
 import com.advancedtelematic.ota.deviceregistry.data.Device.{ActiveDeviceCount, DeviceOemId}
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.PackageId
+import com.advancedtelematic.ota.deviceregistry.data.{GroupExpression, PackageId}
 import com.advancedtelematic.ota.deviceregistry.db._
 import com.advancedtelematic.ota.deviceregistry.messages.{DeleteDeviceRequest, DeviceCreated}
 import eu.timepit.refined.api.Refined

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -11,7 +11,6 @@ package com.advancedtelematic.ota.deviceregistry
 import java.time.{Instant, OffsetDateTime}
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.marshalling.{Marshaller, ToResponseMarshaller}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server._
@@ -20,7 +19,7 @@ import akka.stream.ActorMaterializer
 import cats.syntax.either._
 import cats.syntax.show._
 import com.advancedtelematic.libats.auth.{AuthedNamespaceScope, Scopes}
-import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace, ResultCode, ResultDescription}
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace, ResultCode}
 import com.advancedtelematic.libats.http.UUIDKeyAkka._
 import com.advancedtelematic.libats.messaging.MessageBusPublisher
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId._

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupMembership.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupMembership.scala
@@ -4,9 +4,9 @@ import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.ota.deviceregistry.common.Errors
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId, Name}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupType}
+import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupExpression, GroupName, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.{DeviceRepository, GroupInfoRepository, GroupMemberRepository}
 import slick.jdbc.MySQLProfile.api._
 
@@ -22,7 +22,7 @@ protected class DynamicMembership(implicit db: Database, ec: ExecutionContext) e
 
   def create(
       groupId: GroupId,
-      name: Name,
+      name: GroupName,
       namespace: Namespace,
       expression: GroupExpression
   ): Future[GroupId] = db.run {
@@ -52,7 +52,7 @@ protected class StaticMembership(implicit db: Database, ec: ExecutionContext) ex
   override def removeMember(group: Group, deviceId: DeviceId): Future[Unit] =
     db.run(GroupMemberRepository.removeGroupMember(group.id, deviceId))
 
-  def create(groupId: GroupId, name: Name, namespace: Namespace): Future[GroupId] = db.run {
+  def create(groupId: GroupId, name: GroupName, namespace: Namespace): Future[GroupId] = db.run {
     GroupInfoRepository.create(groupId, name, namespace, GroupType.static, expression = None)
   }
 }
@@ -65,7 +65,7 @@ class GroupMembership(implicit val db: Database, ec: ExecutionContext) {
       case g                                 => fn(g, new DynamicMembership())
     }
 
-  def create(name: Group.Name,
+  def create(name: GroupName,
              namespace: Namespace,
              groupType: GroupType,
              expression: Option[GroupExpression]): Future[GroupId] =

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
@@ -118,7 +118,6 @@ case class CreateGroup(name: GroupName, groupType: GroupType, expression: Option
 object CreateGroup {
   import GroupType._
   import com.advancedtelematic.circe.CirceInstances._
-  import com.advancedtelematic.libats.codecs.CirceRefined._
   import io.circe.generic.semiauto._
 
   implicit val createGroupEncoder: Encoder[CreateGroup] = deriveEncoder

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
@@ -11,33 +11,34 @@ package com.advancedtelematic.ota.deviceregistry
 import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
-import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.http.scaladsl.unmarshalling.{FromStringUnmarshaller, Unmarshaller}
+import cats.syntax.either._
 import com.advancedtelematic.libats.auth.{AuthedNamespaceScope, Scopes}
 import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId, Name}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.data.SortBy.SortBy
 import com.advancedtelematic.ota.deviceregistry.data._
 import com.advancedtelematic.ota.deviceregistry.db.GroupInfoRepository
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.{Decoder, Encoder}
 import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
-import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 
 class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], deviceNamespaceAuthorizer: Directive1[DeviceId])
                     (implicit ec: ExecutionContext, db: Database) extends Directives {
-
-  import com.advancedtelematic.libats.http.RefinedMarshallingSupport._
-  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 
   private val GroupIdPath = {
     def groupAllowed(groupId: GroupId): Future[Namespace] = db.run(GroupInfoRepository.groupInfoNamespace(groupId))
     AllowUUIDPath(GroupId)(namespaceExtractor, groupAllowed)
   }
 
-  implicit val groupTypeParamUnmarshaller: Unmarshaller[String, GroupType] = Unmarshaller.strict[String, GroupType](GroupType.withName)
-  implicit val sortByUnmarshaller: Unmarshaller[String, SortBy] = Unmarshaller.strict {
+  implicit val groupTypeUnmarshaller: FromStringUnmarshaller[GroupType] = Unmarshaller.strict(GroupType.withName)
+  implicit val groupNameUnmarshaller: FromStringUnmarshaller[GroupName] = Unmarshaller.strict(GroupName.validatedGroupName.from(_).valueOr(throw _))
+
+  implicit val sortByUnmarshaller: FromStringUnmarshaller[SortBy] = Unmarshaller.strict {
     _.toLowerCase match {
       case "name"      => SortBy.Name
       case "createdat" => SortBy.CreatedAt
@@ -58,13 +59,13 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
   def getGroup(groupId: GroupId): Route =
     complete(db.run(GroupInfoRepository.findByIdAction(groupId)))
 
-  def createGroup(groupName: Name,
+  def createGroup(groupName: GroupName,
                   namespace: Namespace,
                   groupType: GroupType,
                   expression: Option[GroupExpression]): Route =
     complete(StatusCodes.Created -> groupMembership.create(groupName, namespace, groupType, expression))
 
-  def renameGroup(groupId: GroupId, newGroupName: Name): Route =
+  def renameGroup(groupId: GroupId, newGroupName: GroupName): Route =
     complete(db.run(GroupInfoRepository.renameGroup(groupId, newGroupName)))
 
   def countDevices(groupId: GroupId): Route =
@@ -102,7 +103,7 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
             }
           }
         } ~
-        (scope.put & path("rename") & parameter('groupName.as[Name])) { groupName =>
+        (scope.put & path("rename") & parameter('groupName.as[GroupName])) { groupName =>
           renameGroup(groupId, groupName)
         } ~
         (scope.get & path("count") & pathEnd) {
@@ -112,7 +113,7 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
     }
 }
 
-case class CreateGroup(name: Group.Name, groupType: GroupType, expression: Option[GroupExpression])
+case class CreateGroup(name: GroupName, groupType: GroupType, expression: Option[GroupExpression])
 
 object CreateGroup {
   import GroupType._

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
@@ -10,8 +10,7 @@ package com.advancedtelematic.ota.deviceregistry.common
 
 import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.{EntityAlreadyExists, MissingEntity, RawError}
-import com.advancedtelematic.ota.deviceregistry.data.Group
-import com.advancedtelematic.ota.deviceregistry.data.Group.GroupExpression
+import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupExpression}
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.db.GroupMemberRepository.GroupMember
 import com.advancedtelematic.ota.deviceregistry.db.PublicCredentialsRepository.DevicePublicCredentials

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
@@ -2,7 +2,6 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import io.circe.{Decoder, Encoder}
 import com.advancedtelematic.libats.codecs.CirceAnyVal.{anyValStringEncoder, anyValStringDecoder}
-import com.advancedtelematic.libats.codecs.CirceCodecs.{refinedDecoder, refinedEncoder}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStat, UpdateDevice}
 
 object Codecs {

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.libats.data.EcuIdentifier
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, Event}
 import com.advancedtelematic.ota.deviceregistry.data.CredentialsType.CredentialsType
 import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType.IndexedEventType
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceName, DeviceOemId, DeviceType}
+import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import io.circe.Json

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Device.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Device.scala
@@ -15,9 +15,8 @@ import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import cats.Show
 import cats.syntax.show._
 import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceName, DeviceOemId, DeviceType}
+import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
 import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus._
-import eu.timepit.refined.api.{Refined, Validate}
 import io.circe.{Decoder, Encoder}
 
 final case class Device(namespace: Namespace,
@@ -34,15 +33,6 @@ object Device {
 
   final case class DeviceOemId(underlying: String) extends AnyVal
   implicit val showDeviceOemId: Show[DeviceOemId] = deviceId => deviceId.underlying
-
-  case class ValidDeviceName()
-  type DeviceName = Refined[String, ValidDeviceName]
-  implicit val validDeviceName: Validate.Plain[String, ValidDeviceName] =
-    Validate.fromPredicate(
-      name => name.length < 200,
-      name => s"$name is not a valid DeviceName since it is longer than 200 characters",
-      ValidDeviceName()
-    )
 
   type DeviceType = DeviceType.DeviceType
 

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceName.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceName.scala
@@ -1,0 +1,24 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import com.advancedtelematic.libats.codecs.CirceValidatedGeneric
+import com.advancedtelematic.libats.data.{ValidatedGeneric, ValidationError}
+import io.circe.{Decoder, Encoder}
+
+final case class DeviceName private(value: String) extends AnyVal
+
+object DeviceName {
+
+  implicit val validatedDeviceType = new ValidatedGeneric[DeviceName, String] {
+    override def to(deviceType: DeviceName): String = deviceType.value
+    override def from(s: String): Either[ValidationError, DeviceName] = apply(s)
+  }
+
+  def apply(s: String): Either[ValidationError, DeviceName] =
+    if (s.length > 200)
+      Left(ValidationError(s"$s is not a valid DeviceName since it is longer than 200 characters"))
+    else
+      Right(new DeviceName(s))
+
+  implicit val deviceNameEncoder: Encoder[DeviceName] = CirceValidatedGeneric.validatedGenericEncoder
+  implicit val deviceNameDecoder: Decoder[DeviceName] = CirceValidatedGeneric.validatedGenericDecoder
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpression.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpression.scala
@@ -1,0 +1,27 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import com.advancedtelematic.libats.codecs.CirceValidatedGeneric
+import com.advancedtelematic.libats.data.{ValidatedGeneric, ValidationError}
+import io.circe.{Decoder, Encoder}
+
+final case class GroupExpression private (value: String) extends AnyVal
+
+object GroupExpression {
+
+  implicit val validatedGroupExpression = new ValidatedGeneric[GroupExpression, String] {
+    override def to(expression: GroupExpression): String                   = expression.value
+    override def from(s: String): Either[ValidationError, GroupExpression] = apply(s)
+  }
+
+  def apply(s: String): Either[ValidationError, GroupExpression] =
+    if (s.length < 1 || s.length > 200)
+      Left(ValidationError("The expression is too small or too big."))
+    else
+      GroupExpressionParser.parse(s).fold(
+        e => Left(ValidationError(e.desc)),
+        _ => Right(new GroupExpression(s))
+      )
+
+  implicit val groupExpressionEncoder: Encoder[GroupExpression] = CirceValidatedGeneric.validatedGenericEncoder
+  implicit val groupExpressionDecoder: Decoder[GroupExpression] = CirceValidatedGeneric.validatedGenericDecoder
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParser.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupExpressionParser.scala
@@ -7,7 +7,6 @@ import cats.syntax.either._
 import com.advancedtelematic.libats.http.Errors.RawError
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.ota.deviceregistry.common.Errors
-import com.advancedtelematic.ota.deviceregistry.data.Group.GroupExpression
 import com.advancedtelematic.ota.deviceregistry.data.GroupExpressionAST._
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository.DeviceTable
 import slick.jdbc.MySQLProfile.api._

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupName.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/GroupName.scala
@@ -1,0 +1,24 @@
+package com.advancedtelematic.ota.deviceregistry.data
+
+import com.advancedtelematic.libats.codecs.CirceValidatedGeneric
+import com.advancedtelematic.libats.data.{ValidatedGeneric, ValidationError}
+import io.circe.{Decoder, Encoder}
+
+final case class GroupName private(value: String) extends AnyVal
+
+object GroupName {
+
+  implicit val validatedGroupName = new ValidatedGeneric[GroupName, String] {
+    override def to(expression: GroupName): String = expression.value
+    override def from(s: String): Either[ValidationError, GroupName] = apply(s)
+  }
+
+  def apply(s: String): Either[ValidationError, GroupName] =
+    if (s.length < 2 || s.length > 100)
+      Left(ValidationError(s"$s should be between two and a hundred alphanumeric characters long."))
+    else
+      Right(new GroupName(s))
+
+  implicit val groupNameEncoder: Encoder[GroupName] = CirceValidatedGeneric.validatedGenericEncoder
+  implicit val groupNameDecoder: Decoder[GroupName] = CirceValidatedGeneric.validatedGenericDecoder
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DbOps.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DbOps.scala
@@ -1,8 +1,7 @@
 package com.advancedtelematic.ota.deviceregistry.db
 
-import com.advancedtelematic.libats.slick.codecs.SlickRefined._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
-import com.advancedtelematic.ota.deviceregistry.data.Group._
+import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
 import com.advancedtelematic.ota.deviceregistry.data.SortBy
 import com.advancedtelematic.ota.deviceregistry.data.SortBy.SortBy
 import com.advancedtelematic.ota.deviceregistry.db.GroupInfoRepository.GroupInfoTable

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
@@ -21,7 +21,7 @@ import com.advancedtelematic.ota.deviceregistry.common.Errors
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, DeletedDevice, SearchParams}
 import com.advancedtelematic.ota.deviceregistry.data.Device._
 import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus.DeviceStatus
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.data._
 import com.advancedtelematic.ota.deviceregistry.db.DbOps.PaginationResultOps

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
@@ -13,10 +13,10 @@ import java.time.Instant
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import com.advancedtelematic.libats.slick.codecs.SlickRefined._
 import com.advancedtelematic.libats.slick.db.SlickAnyVal._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.libats.slick.db.SlickValidatedGeneric.validatedStringMapper
 import com.advancedtelematic.ota.deviceregistry.common.Errors
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, DeletedDevice, SearchParams}
 import com.advancedtelematic.ota.deviceregistry.data.Device._
@@ -28,8 +28,6 @@ import com.advancedtelematic.ota.deviceregistry.db.DbOps.PaginationResultOps
 import com.advancedtelematic.ota.deviceregistry.db.GroupInfoRepository.groupInfos
 import com.advancedtelematic.ota.deviceregistry.db.GroupMemberRepository.groupMembers
 import com.advancedtelematic.ota.deviceregistry.db.SlickMappings._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.string.Regex
 import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeviceCreated.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/messages/DeviceCreated.scala
@@ -12,8 +12,9 @@ import java.time.Instant
 
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.MessageLike
-import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceName, DeviceType}
+import com.advancedtelematic.ota.deviceregistry.data.Device.{DeviceOemId, DeviceType}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName
 
 final case class DeviceCreated(namespace: Namespace,
                                uuid: DeviceId,

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -131,12 +131,13 @@ trait DeviceRequests { self: ResourceSpec =>
       status shouldBe StatusCodes.NoContent
     }
 
-  def listPackages(device: DeviceId, regex: Option[String] = None)(implicit ec: ExecutionContext): HttpRequest =
-    regex match {
-      case Some(r) =>
-        Get(Resource.uri("devices", device.show, "packages").withQuery(Query("regex" -> r)))
-      case None => Get(Resource.uri("devices", device.show, "packages"))
+  def listPackages(device: DeviceId, nameContains: Option[String] = None)(implicit ec: ExecutionContext): HttpRequest = {
+    val uri = Resource.uri("devices", device.show, "packages")
+    nameContains match {
+      case None => Get(uri)
+      case Some(s) => Get(uri.withQuery(Query("nameContains" -> s)))
     }
+  }
 
   def getStatsForPackage(pkg: PackageId)(implicit ec: ExecutionContext): HttpRequest =
     Get(Resource.uri("device_count", pkg.name, pkg.version))

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -11,8 +11,7 @@ package com.advancedtelematic.ota.deviceregistry
 import java.time.OffsetDateTime
 
 import akka.http.scaladsl.model.Uri.{Path, Query}
-import akka.http.scaladsl.model.headers.Accept
-import akka.http.scaladsl.model.{HttpRequest, MediaTypes, StatusCodes, Uri}
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes, Uri}
 import akka.http.scaladsl.server.Route
 import cats.syntax.show._
 import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace}
@@ -23,10 +22,8 @@ import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsL
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, UpdateDevice}
 import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.PackageId
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, PackageId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.string.Regex
 import io.circe.Json
 
 import scala.concurrent.ExecutionContext

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -20,9 +20,9 @@ import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.DataType.InstallationStatsLevel.InstallationStatsLevel
 import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, UpdateDevice}
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, GroupId}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
-import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, PackageId}
+import com.advancedtelematic.ota.deviceregistry.data.{DeviceName, GroupExpression, PackageId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResourceSpec.scala
@@ -27,9 +27,6 @@ import com.advancedtelematic.ota.deviceregistry.data.{Device, DeviceStatus, Pack
 import com.advancedtelematic.ota.deviceregistry.db.InstalledPackages
 import com.advancedtelematic.ota.deviceregistry.db.InstalledPackages.{DevicesCount, InstalledPackage}
 import com.advancedtelematic.ota.deviceregistry.messages.DeleteDeviceRequest
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.refineMV
-import eu.timepit.refined.string.Regex
 import io.circe.generic.auto._
 import org.scalacheck.Arbitrary._
 import org.scalacheck.{Gen, Shrink}

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
@@ -7,31 +7,24 @@ import com.advancedtelematic.libats.data.{ErrorCodes, ErrorRepresentation, Pagin
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
-import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, ValidExpression, _}
-import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupType}
+import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
+import com.advancedtelematic.ota.deviceregistry.data.{GroupExpression, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.refineV
-import io.circe.Decoder
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.SpanSugar._
 
 class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventually {
 
-  import com.advancedtelematic.libats.codecs.CirceCodecs._
-  import io.circe.generic.semiauto.deriveDecoder
-
-  private[this] implicit val GroupDecoder: Decoder[Group] = deriveDecoder[Group]
-
   implicit class DeviceIdToExpression(value: DeviceOemId) {
     def toValidExp: GroupExpression =
-      refineV[ValidExpression](s"deviceid contains ${value.underlying}").valueOr(err => throw new IllegalArgumentException(err))
+      GroupExpression(s"deviceid contains ${value.underlying}").valueOr(err => throw new IllegalArgumentException(err))
   }
 
   test("dynamic group gets created.") {
-    createGroup(GroupType.dynamic, Some(Refined.unsafeApply("deviceid contains something")), None) ~> route ~> check {
+    createGroup(GroupType.dynamic, Some(GroupExpression("deviceid contains something").right.get), None) ~> route ~> check {
       status shouldBe Created
     }
   }
@@ -50,7 +43,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("dynamic group is empty when no device matches the expression") {
-    val groupId    = createDynamicGroupOk(Refined.unsafeApply("deviceid contains nothing"))
+    val groupId    = createDynamicGroupOk(GroupExpression("deviceid contains nothing").right.get)
 
     listDevicesInGroup(groupId) ~> route ~> check {
       status shouldBe OK
@@ -60,7 +53,15 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("dynamic group with invalid expression is not created") {
-    createGroup(GroupType.dynamic, Some(Refined.unsafeApply("")), None) ~> route ~> check {
+    val body = io.circe.parser.parse(
+      """
+        | {
+        |   "name"       : "some name",
+        |   "groupType"  : "dynamic",
+        |   "expression" : ""
+        | }
+      """.stripMargin).valueOr(throw _)
+    createGroup(body) ~> route ~> check {
       status shouldBe BadRequest
       responseAs[ErrorRepresentation].code shouldBe ErrorCodes.InvalidEntity
     }
@@ -121,9 +122,9 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
-    val expression1 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceId.show.substring(0, 5)}") // To test "starts with"
+    val expression1 = GroupExpression(s"deviceid contains ${deviceId.show.substring(0, 5)}").right.get // To test "starts with"
     val groupId1    = createDynamicGroupOk(expression1)
-    val expression2 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceId.show.substring(2, 10)}") // To test "contains"
+    val expression2 = GroupExpression(s"deviceid contains ${deviceId.show.substring(2, 10)}").right.get // To test "contains"
     val groupId2    = createDynamicGroupOk(expression2)
 
     getGroupsOfDevice(deviceUuid) ~> route ~> check {
@@ -140,9 +141,9 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
-    val expression1 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceId.show.substring(0, 3)} and deviceid contains ${deviceId.show.substring(6, 9)}")
+    val expression1 = GroupExpression(s"deviceid contains ${deviceId.show.substring(0, 3)} and deviceid contains ${deviceId.show.substring(6, 9)}").right.get
     val groupId1    = createDynamicGroupOk(expression1)
-    val expression2 = Refined.unsafeApply[String, ValidExpression](s"deviceid contains 0empty0")
+    val expression2 = GroupExpression(s"deviceid contains 0empty0").right.get
     val _    = createDynamicGroupOk(expression2)
 
     getGroupsOfDevice(deviceUuid) ~> route ~> check {
@@ -162,7 +163,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
     addDeviceToGroupOk(staticGroupId, deviceUuid)
 
     // Make the device show up for a dynamic group
-    val expression = Refined.unsafeApply[String, ValidExpression](s"deviceid contains ${deviceT.deviceId.show.substring(1, 5)}")
+    val expression = GroupExpression(s"deviceid contains ${deviceT.deviceId.show.substring(1, 5)}").right.get
     val dynamicGroupId = createDynamicGroupOk(expression)
 
     getGroupsOfDevice(deviceUuid) ~> route ~> check {

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
@@ -6,6 +6,7 @@ import cats.syntax.show._
 import com.advancedtelematic.libats.data.{ErrorCodes, ErrorRepresentation, PaginationResult}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Group.{GroupExpression, ValidExpression, _}
 import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
@@ -116,7 +117,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device returns the correct dynamic groups") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("12347890800808"))
+    val deviceT = genDeviceT.sample.get.copy(deviceName = validatedDeviceType.from("12347890800808").right.get)
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
@@ -135,7 +136,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device using two 'contains' returns the correct dynamic groups") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("ABCDEFGHIJ"))
+    val deviceT = genDeviceT.sample.get.copy(deviceName = validatedDeviceType.from("ABCDEFGHIJ").right.get)
     val deviceId: DeviceOemId = deviceT.deviceId
     val deviceUuid = createDeviceOk(deviceT)
 
@@ -153,7 +154,7 @@ class DynamicGroupsResourceSpec extends FunSuite with ResourceSpec with Eventual
   }
 
   test("getting the groups of a device returns the correct groups (dynamic and static)") {
-    val deviceT = genDeviceT.sample.get.copy(deviceName = Refined.unsafeApply("ABCDE"))
+    val deviceT = genDeviceT.sample.get.copy(deviceName = validatedDeviceType.from("ABCDE").right.get)
     val deviceUuid = createDeviceOk(deviceT)
 
     // Add the device to a static group

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DynamicGroupsResourceSpec.scala
@@ -11,7 +11,6 @@ import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.{GroupExpression, GroupType}
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
-import eu.timepit.refined.api.Refined
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.SpanSugar._

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeleteDeviceHandlerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/daemon/DeleteDeviceHandlerSpec.scala
@@ -6,7 +6,6 @@ import com.advancedtelematic.ota.deviceregistry.data.GeneratorOps
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.test.DatabaseSpec
-import java.util.UUID
 import org.scalacheck.Gen
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
@@ -23,7 +22,7 @@ final class DeleteDeviceHandlerSpec
   val handler = new DeleteDeviceHandler()
 
   test("OTA-2445: do not fail when deleting non-existent device") {
-    val msg = DeleteDeviceRequest(Gen.identifier.map(Namespace).generate, Gen.uuid.map(DeviceId(_)).generate)
+    val msg = DeleteDeviceRequest(Gen.identifier.map(Namespace(_)).generate, Gen.uuid.map(DeviceId(_)).generate)
     handler(msg).futureValue shouldBe Done
   }
 }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
@@ -8,13 +8,13 @@
 
 package com.advancedtelematic.ota.deviceregistry.data
 
-import eu.timepit.refined.api.Refined
-import org.scalacheck.{Arbitrary, Gen}
 import java.time.Instant
 
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName.validatedDeviceType
 import com.advancedtelematic.ota.deviceregistry.data.Namespaces.defaultNs
+import org.scalacheck.{Arbitrary, Gen}
 
 trait DeviceGenerators {
 
@@ -25,7 +25,7 @@ trait DeviceGenerators {
     //use a minimum length for DeviceName to reduce possibility of naming conflicts
     size <- Gen.choose(10, 100)
     name <- Gen.containerOfN[Seq, Char](size, Gen.alphaNumChar)
-  } yield Refined.unsafeApply(name.mkString)
+  } yield validatedDeviceType.from(name.mkString).right.get
 
   val genDeviceUUID: Gen[DeviceId] = Gen.delay(DeviceId.generate)
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupGenerators.scala
@@ -10,22 +10,21 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
-import eu.timepit.refined.api.Refined
 import org.scalacheck.{Arbitrary, Gen}
 
 trait GroupGenerators {
 
   private lazy val defaultNs: Namespace = Namespace("default")
 
-  def genGroupName(charGen: Gen[Char] = Arbitrary.arbChar.arbitrary): Gen[Group.Name] = for {
+  def genGroupName(charGen: Gen[Char] = Arbitrary.arbChar.arbitrary): Gen[GroupName] = for {
     strLen <- Gen.choose(2, 100)
     name   <- Gen.listOfN[Char](strLen, charGen)
-  } yield Refined.unsafeApply(name.mkString)
+  } yield GroupName(name.mkString).right.get
 
   def genStaticGroup: Gen[Group] =
     genGroupName().flatMap(Group(GroupId.generate(), _, defaultNs, GroupType.static, None))
 
-  implicit lazy val arbGroupName: Arbitrary[Group.Name] = Arbitrary(genGroupName())
+  implicit lazy val arbGroupName: Arbitrary[GroupName] = Arbitrary(genGroupName())
   implicit lazy val arbStaticGroup: Arbitrary[Group] = Arbitrary(genStaticGroup)
 }
 

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/PackageIdGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/PackageIdGenerators.scala
@@ -10,7 +10,6 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import java.security.InvalidParameterException
 
-import eu.timepit.refined.api.Refined
 import org.scalacheck.{Arbitrary, Gen}
 
 trait PackageIdGenerators {

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/SemanticVin.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/SemanticVin.scala
@@ -10,8 +10,6 @@ package com.advancedtelematic.ota.deviceregistry.data
 
 import cats.Show
 import cats.syntax.show._
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.string.Regex
 import org.scalacheck.Gen
 
 // https://en.wikipedia.org/wiki/VIN
@@ -45,15 +43,6 @@ object SemanticVin {
       plantCode <- genPlantCode
       seqNum    <- Gen.choose(100000, 999999)
     } yield SemanticVin(wmi, vehAttr, checkDig, modelYr, plantCode, seqNum)
-
-  def genVinRegex: Gen[Refined[String, Regex]] =
-    for {
-      part <- Gen.frequency(
-        (1, genVehicleAttributes.map(_.show)),
-        (1, genPlantCode.map(_.show)),
-        (1, genModelYear.map(_.show))
-      )
-    } yield Refined.unsafeApply("^.*" + part + ".*$")
 
   // World manufacturer identifier (3 characters).
   sealed trait WMI


### PR DESCRIPTION
I remember we discussed getting rid of the `Refined` library, and that's why we implemented our `ValidatedGeneric` in libats. (Unfortunately I don't remember exactly why, but @koshelev might be able to fill that gap.) So, if this is still something worth doing, we can gradually do this for the various services and eventually remove `Refined` as a dependency in libats.

To be merged and deployed with https://github.com/advancedtelematic/ota-plus-server/pull/1997.