### PR TITLE
Use akka-stream-kafka version used by libats-messaging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val `ota-device-registry` =
       libraryDependencies += "org.tpolecat" %% "atto-core" % "0.6.2"
     )
     .settings(libraryDependencies ++= library.libAts)
-    .settings(dependencyOverrides += "com.typesafe.akka" %% "akka-stream-kafka" % "1.0.4")
+    .settings(dependencyOverrides += "com.typesafe.akka" %% "akka-stream-kafka" % "0.19")
 
 // *****************************************************************************
 // Library dependencies


### PR DESCRIPTION
Latest version in incompatible, error is:

java.lang.NoSuchMethodError: akka.kafka.ProducerSettings.createKafkaProducer()Lorg/apache/kafka/clients/producer/KafkaProducer;
	at com.advancedtelematic.libats.messaging.kafka.KafkaClient$.producer(KafkaClient.scala:126)
	at com.advancedtelematic.libats.messaging.kafka.KafkaClient$.publisher(KafkaClient.scala:34)
	at com.advancedtelematic.libats.messaging.MessageBus$.publisher(MessageBus.scala:96)
	at com.advancedtelematic.ota.deviceregistry.Boot$.messageBus$lzycompute(Boot.scala:84)
	at com.advancedtelematic.ota.deviceregistry.Boot$.messageBus(Boot.scala:84)
	at com.advancedtelematic.ota.deviceregistry.Boot$.delayedEndpoint$com$advancedtelematic$ota$deviceregistry$Boot$1(Boot.scala:105)
	at com.advancedtelematic.ota.deviceregistry.Boot$delayedInit$body.apply(Boot.scala:61)
	at scala.Function0.apply$mcV$sp(Function0.scala:39)
	at scala.Function0.apply$mcV$sp$(Function0.scala:39)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
	at scala.App.$anonfun$main$1$adapted(App.scala:80)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at scala.App.main(App.scala:80)
	at scala.App.main$(App.scala:78)
	at com.advancedtelematic.ota.deviceregistry.Boot$.main(Boot.scala:61)
	at com.advancedtelematic.ota.deviceregistry.Boot.main(Boot.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)