### PR TITLE
[OTA-3179] Correctly parse a CSV exported from a spreadsheet

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
@@ -80,7 +80,7 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
                              byteSource: Source[ByteString, Any])
                             (implicit materializer: ActorMaterializer): Route = {
     val deviceUuids = byteSource
-      .via(Framing.delimiter(ByteString("\n"), DEVICE_OEM_ID_MAX_BYTES))
+      .via(Framing.delimiter(ByteString("\n"), DEVICE_OEM_ID_MAX_BYTES, allowTruncation = true))
       .map(_.utf8String.toString)
       .map(DeviceOemId)
       .batch(FILTER_EXISTING_DEVICES_BATCH_SIZE, Set(_))(_ + _)

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupRequests.scala
@@ -70,12 +70,11 @@ trait GroupRequests {
     Post(Resource.uri(groupsApi), CreateGroup(name, groupType, expr))
   }
 
-  def importGroup(groupName: GroupName, oemIds: Seq[DeviceOemId], malformed: Boolean = false): HttpRequest = {
-    val endString = if (malformed) "" else "\n"
+  def importGroup(groupName: GroupName, oemIds: Seq[DeviceOemId]): HttpRequest = {
     val multipartForm = Multipart.FormData(
       Multipart.FormData.BodyPart.Strict(
         "deviceIds",
-        HttpEntity(ContentTypes.`text/csv(UTF-8)`, oemIds.map(_.underlying).mkString("", "\n", endString)),
+        HttpEntity(ContentTypes.`text/csv(UTF-8)`, oemIds.map(_.underlying).mkString("\n")),
         Map("filename" -> "vins.csv")))
     Post(Resource.uri(groupsApi).withQuery(Query("groupName" -> groupName.value)), multipartForm)
   }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/GroupsResourceSpec.scala
@@ -17,6 +17,7 @@ import org.scalacheck.Gen
 import akka.http.scaladsl.model.StatusCodes._
 import com.advancedtelematic.libats.data.{ErrorRepresentation, PaginationResult}
 import com.advancedtelematic.ota.deviceregistry.common.Errors.Codes.MalformedInput
+import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.ScalaFutures
 
@@ -253,11 +254,11 @@ class GroupsResourceSpec extends FunSuite with ResourceSpec with ScalaFutures {
     }
   }
 
-  test("creating a static group from a file fails with 400 if the file is not properly formatted") {
+  test("creating a static group from a file fails with 400 if the deviceIds are longer than it's allowed") {
     val groupName = genGroupName().sample.get
-    val deviceTs = Gen.listOf(genDeviceT).sample.get
+    val oemId = Gen.listOfN(130, Gen.alphaNumChar).map(_.mkString).map(DeviceOemId).sample.get
 
-    importGroup(groupName, deviceTs.map(_.deviceId), malformed = true) ~> route ~> check {
+    importGroup(groupName, Seq(oemId)) ~> route ~> check {
       status shouldEqual BadRequest
       responseAs[ErrorRepresentation].code shouldBe MalformedInput
     }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepositorySpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepositorySpec.scala
@@ -10,7 +10,7 @@ package com.advancedtelematic.ota.deviceregistry.db
 
 import java.time.Instant
 
-import com.advancedtelematic.libats.test.DatabaseSpec
+import com.advancedtelematic.libats.test.{DatabaseSpec, LongTest}
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
 import com.advancedtelematic.ota.deviceregistry.data.DeviceGenerators.{genDeviceId, genDeviceT}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeletedDevice
@@ -24,7 +24,7 @@ import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DeviceRepositorySpec extends FunSuite with DatabaseSpec with ScalaFutures with Matchers {
+class DeviceRepositorySpec extends FunSuite with DatabaseSpec with ScalaFutures with Matchers with LongTest {
 
   test("updateLastSeen sets activated_at the first time only") {
 


### PR DESCRIPTION
The current implementation fails because exporting as CSV from a spreadsheet application doesn't add a line break after the last record.