### PR TITLE
Sort installation history items in descending order (from newest to oldest)

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstallationReportRepository.scala
@@ -125,7 +125,7 @@ object InstallationReportRepository {
                               (implicit ec: ExecutionContext): DBIO[PaginationResult[Json]] =
     deviceInstallationResults
       .filter(_.deviceUuid === deviceId)
-      .sortBy(_.receivedAt.asc)
+      .sortBy(_.receivedAt.desc)
       .map(_.installationReport)
       .paginateResult(offset.orDefaultOffset, limit.orDefaultLimit)
 


### PR DESCRIPTION
Fixes #78 which introduced sorting in _ascending_ (from oldest to newest) order.
_Mildly related_ to OTA-3105 because re-ordering also occurs on the FE side