### PR TITLE
Only build docker image on push to master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,6 @@ build docker image:
   stage: build image
   only:
     - master
-    - /^deploy\/.*/
   tags:
     - docker-sock
   variables:


### PR DESCRIPTION
This means that `git push deploy/sit` will not work if the revision
was not previously pushed to master, as the image to deploy would not
have been built yet. IMO this is a good thing as only revisions in
master can be deployed to SIT, but it might not be obvious when the
deployment fails.