### PR TITLE
Add static code checks to gitlab CD integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ stages:
   - test
   - build image
   - trigger deploy
+  - publish
 
 variables:
   MYSQL_ROOT_PASSWORD: "root"
@@ -78,3 +79,51 @@ trigger sit deploy:
   trigger:
     project: OLP/EDGE/OTA/infra/deployment-descriptors
     branch: master    
+
+
+trigger veracode scan:
+  # prepare and submit for static code analysis
+  stage: trigger deploy
+  only:
+    variables:
+      - $VERACODE_API_ID
+  image: advancedtelematic/gitlab-jobs:0.1.0
+  before_script:
+    # The latest wrapper version can be found in https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/
+    - wget -q -O veracode-wrapper.jar https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/${VERACODE_WRAPPER_VERSION}/vosp-api-wrappers-java-${VERACODE_WRAPPER_VERSION}.jar
+    - ./sbt package
+    - mv target/scala-*/device-registry_*.jar ./scan.jar
+  script:
+    - java -jar veracode-wrapper.jar -vid ${VERACODE_API_ID} -vkey ${VERACODE_API_KEY}
+      -action UploadAndScan -appname "OTA Backend - device registry" -createprofile true -autoscan true
+      -filepath scan.jar -version "job ${CI_JOB_ID} in pipeline ${CI_PIPELINE_ID} for ${CI_PROJECT_NAME} repo"
+  artifacts:
+    paths:
+      - scan.jar
+
+trigger-deps-scan:
+  # perform dependencies CVE analysis
+  stage: trigger deploy
+  only:
+    - schedules
+  image: advancedtelematic/gitlab-jobs:0.1.0
+  script:
+    - ./sbt dependencyCheckAggregate
+    - mv target/scala-*/dependency-check-report.html ./depchk.html
+  artifacts:
+    paths:
+      - depchk.html
+
+pages:
+  stage: publish
+  only:
+    - schedules
+  dependencies:
+    - trigger-deps-scan
+  script:
+    - mkdir -p public
+    - mv depchk.html public/index.html
+  artifacts:
+    paths:
+      - public
+    expire_in: 64 days


### PR DESCRIPTION
The veracode pipeline is intended to be run as part of schedule only.
Test run: https://main.gitlab.in.here.com/olp/edge/ota/connect/back-end/ota-device-registry/pipelines/98127
Generated report: https://olp.pages.gitlab.in.here.com/edge/ota/connect/back-end/ota-device-registry/