### PR TITLE
Fix flaky test.

### DIFF
--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -185,7 +185,7 @@ trait DeviceRequests { self: ResourceSpec =>
   def getGroupsOfDevice(deviceUuid: DeviceId): HttpRequest = Get(Resource.uri(api, deviceUuid.show, "groups"))
 
   def getDevicesByGrouping(grouped: Boolean, groupType: Option[GroupType],
-                           nameContains: Option[String] = None, limit: Long = 1000): HttpRequest = {
+                           nameContains: Option[String] = None, limit: Long = 2000): HttpRequest = {
     val m = Map("grouped" -> grouped, "limit" -> limit) ++
       List("groupType" -> groupType, "nameContains" -> nameContains).collect { case (k, Some(v)) => k -> v }.toMap
     Get(Resource.uri(api).withQuery(Query(m.mapValues(_.toString))))

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/DeviceGenerators.scala
@@ -23,7 +23,7 @@ trait DeviceGenerators {
 
   val genDeviceName: Gen[DeviceName] = for {
     //use a minimum length for DeviceName to reduce possibility of naming conflicts
-    size <- Gen.choose(10, 100)
+    size <- Gen.choose(50, 200)
     name <- Gen.containerOfN[Seq, Char](size, Gen.alphaNumChar)
   } yield validatedDeviceType.from(name.mkString).right.get
 


### PR DESCRIPTION
This silly test fails sometimes because we create too many test objects and retrieve too few.