### PR TITLE
Add number of devices to the 'list groups' endpoint.

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/GroupsResource.scala
@@ -22,6 +22,7 @@ import com.advancedtelematic.libats.auth.{AuthedNamespaceScope, Scopes}
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.deviceregistry.common.Errors
+import com.advancedtelematic.ota.deviceregistry.data.Codecs.groupWithCountCodec
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
@@ -63,8 +64,10 @@ class GroupsResource(namespaceExtractor: Directive1[AuthedNamespaceScope], devic
       complete(groupMembership.listDevices(groupId, offset, limit))
     }
 
-  def listGroups(ns: Namespace, offset: Option[Long], limit: Option[Long], sortBy: SortBy, nameContains: Option[String]): Route =
-    complete(db.run(GroupInfoRepository.list(ns, offset, limit, sortBy, nameContains)))
+  def listGroups(ns: Namespace, offset: Option[Long], limit: Option[Long], sortBy: SortBy, nameContains: Option[String]): Route = {
+    val f = GroupInfoRepository.list(ns, offset, limit, sortBy, nameContains)
+    complete(db.run(f))
+  }
 
   def getGroup(groupId: GroupId): Route =
     complete(db.run(GroupInfoRepository.findByIdAction(groupId)))

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
@@ -16,4 +16,6 @@ object Codecs {
 
   implicit val installationStatEncoder = io.circe.generic.semiauto.deriveEncoder[InstallationStat]
   implicit val installationStatDecoder = io.circe.generic.semiauto.deriveDecoder[InstallationStat]
+
+  implicit val groupWithCountCodec = io.circe.generic.semiauto.deriveCodec[GroupWithCount]
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Group.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Group.scala
@@ -28,6 +28,14 @@ case class Group(id: GroupId,
                  groupType: GroupType,
                  expression: Option[GroupExpression] = None)
 
+case class GroupWithCount(id: GroupId,
+                          groupName: GroupName,
+                          namespace: Namespace,
+                          deviceCount: Int,
+                          createdAt: Instant,
+                          groupType: GroupType,
+                          expression: Option[GroupExpression] = None)
+
 object GroupType extends Enumeration {
   type GroupType = Value
 

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DbOps.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DbOps.scala
@@ -9,10 +9,10 @@ import com.advancedtelematic.ota.deviceregistry.db.GroupInfoRepository.GroupInfo
 import slick.jdbc.MySQLProfile.api._
 
 object DbOps {
-  implicit def sortBySlickOrderedConversion(sortBy: SortBy): GroupInfoTable => slick.lifted.Ordered =
+  implicit def sortBySlickOrderedGroupTuple2Conversion(sortBy: SortBy): ((GroupInfoTable, Any)) => slick.lifted.Ordered =
     sortBy match {
-      case SortBy.Name      => table => table.groupName.asc
-      case SortBy.CreatedAt => table => table.createdAt.desc
+      case SortBy.Name      => { case (table, _) => table.groupName.asc }
+      case SortBy.CreatedAt => { case (table, _) => table.createdAt.desc }
     }
 
   implicit def sortBySlickOrderedDeviceConversion(sortBy: SortBy): DeviceTable => slick.lifted.Ordered =

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupGenerators.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/data/GroupGenerators.scala
@@ -11,6 +11,8 @@ package com.advancedtelematic.ota.deviceregistry.data
 import java.time.Instant
 
 import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
+import com.advancedtelematic.ota.deviceregistry.data.DeviceGenerators.genDeviceT
 import com.advancedtelematic.ota.deviceregistry.data.Group.GroupId
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -27,6 +29,14 @@ trait GroupGenerators {
     groupName <- genGroupName()
     createdAt <- Gen.resize(1000000000, Gen.posNum[Long]).map(Instant.ofEpochSecond)
   } yield Group(GroupId.generate(), groupName, defaultNs, createdAt, GroupType.static, None)
+
+  val genGroupNameWithDeviceTs: Gen[(GroupName, List[DeviceT])] = for {
+    groupName <- genGroupName()
+    deviceTs <- Gen.resize(10, Gen.listOf(genDeviceT))
+  } yield groupName -> deviceTs
+
+  def genGroupNameWithDeviceTsMap(size: Int = 10): Gen[Map[GroupName, Seq[DeviceT]]] =
+    Gen.resize(size, Gen.listOf(genGroupNameWithDeviceTs)).map(_.toMap)
 
   implicit lazy val arbGroupName: Arbitrary[GroupName] = Arbitrary(genGroupName())
   implicit lazy val arbStaticGroup: Arbitrary[Group] = Arbitrary(genStaticGroup)


### PR DESCRIPTION
Wouldn't say this is very elegant, but it's needed for OTA-3667 (dashboard page of the new UI). In the "recently created" view we want to show how many devices there are in the groups.