### PR TITLE
Fix multiple errors with `system_info` endpoints

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -245,7 +245,7 @@ class DevicesResource(
             fetchDevice(uuid)
           }
         } ~
-        (scope.put & entity(as[UpdateDevice]) & pathEnd) { updateBody =>
+        (scope.put & pathEnd & entity(as[UpdateDevice])) { updateBody =>
           updateDevice(ns.namespace, uuid, updateBody)
         } ~
         (scope.delete & pathEnd) {

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/SystemInfoResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/SystemInfoResource.scala
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory
 import slick.jdbc.MySQLProfile.api._
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.http.UUIDKeyAkka._
+import cats.syntax.show._
 
 import scala.concurrent.ExecutionContext
 
@@ -126,8 +127,8 @@ class SystemInfoResource(
     }
 
   def mydeviceRoutes: Route = authNamespace { authedNs => // don't use this as a namespace
-    path("mydevice" / DeviceId.Path) { uuid =>
-      (put & path("system_info") & authedNs.oauthScope(s"ota-core.{uuid.show}.write")) {
+    pathPrefix("mydevice" / DeviceId.Path) { uuid =>
+      (put & path("system_info") & authedNs.oauthScope(s"ota-core.${uuid.show}.write")) {
         entity(as[Json]) { body =>
           updateSystemInfo(authedNs.namespace, uuid, body)
         }


### PR DESCRIPTION
`mydevice/:uuid` was broken due the usage of `path` instead of
`pathPrefix`, so this route was never used. This route is currently
used by devices through device gateway, which proxys
`/core/system_info` to this route. Devices have been receiving a 404
for a long time.

The other error is a little more subtle and required a lot of time to
debug.

This affects the endpoint `/devices/:uuid/system_info`.

We noticed that somes a request with a big json file would fail, but
sometimes it would work. At first this seemed like an issue introduced
by upgrading akka-http or circe-akka-http, but on closer look we
noticed that two different resources are using the same
`/devices/:uuid` prefix. The first resource, DevicesResource, had
route that matches `/devices/:uuid <pathEnd>`, but only after trying
to parse a json entity to `DeviceName`. If the path then did not match
`<pathEnd>` the request matching would continue to the next path, but
the json entity would already be consumed. With akka streams, the
entity can only be consumed once. When the route match continued, it
would eventually match the other resource using the `/devices/:uuid`
prefix, which in this case would be a route in `SystemInfoResource`,
at `/devices/:uuid/system_info`. This route would match, but the json
entity would already be consumed, so the json parsing would fail.

We fixed this by rejecting the route before starting the json parsing,
if the path does not fully match. This way the entity remains valid
and readable until it's matched in `SystemInfoResource`.

Two resources should never share the same route prefix, other that
`/api/vx/`, otherwise these types of errors get more complicated to
resolve than they need to be.

Signed-off-by: Simão Mata <simao.mata@here.com>