### PR TITLE
Upgrade libats.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val library =
     object Version {
       val scalaCheck = "1.14.1"
       val scalaTest  = "3.0.8"
-      val libAts     = "0.3.0-42-g1ccbae7"
+      val libAts     = "0.3.0-46-g417e029"
       val akka = "2.5.25"
       val akkaHttp = "10.1.10"
       val mariaDb = "2.4.4"


### PR DESCRIPTION
The latest version of libats fixes an issue with the Flyway upgrade.