### PR TITLE
Remove flyway sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,9 +73,7 @@ commonSettings ++
 gitSettings ++
 scalafmtSettings ++
 buildInfoSettings ++
-dockerSettings ++
-flywaySettings
-
+dockerSettings
 
 lazy val commonSettings =
   Seq(
@@ -131,10 +129,4 @@ lazy val buildInfoSettings = Seq(
   buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
   buildInfoPackage := organization.value,
   buildInfoOptions ++= Seq(BuildInfoOption.ToJson, BuildInfoOption.ToMap)
-)
-
-lazy val flywaySettings = Seq(
-  flywayUrl := sys.env.get("DEVICE_REGISTRY_DB_URL").orElse(sys.props.get("device-registry.db.url")).getOrElse("jdbc:mysql://localhost:3306/device_registry"),
-  flywayUser := sys.env.get("DEVICE_REGISTRY_DB_USER").orElse(sys.props.get("device-registry.db.user")).getOrElse("device_registry"),
-  flywayPassword := sys.env.get("DEVICE_REGISTRY_DB_PASSWORD").orElse(sys.props.get("device-registry.db.password")).getOrElse("device_registry")
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,5 @@ addSbtPlugin("com.eed3si9n"      % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "1.3.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.4.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
-resolvers += "Flyway" at "https://davidmweber.github.io/flyway-sbt.repo"
 resolvers += "Central" at "http://nexus.advancedtelematic.com:8081/content/repositories/central"
-addSbtPlugin("org.flywaydb" % "flyway-sbt" % "4.2.0")
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25" // Needed by sbt-git


### PR DESCRIPTION
This plugin is not used. We always run the migrations using the Flyway Java
API directly through `libats-slick`.