### PR TITLE
Publish latest tag when building image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val dockerSettings = Seq(
   dockerRepository := Some("advancedtelematic"),
   packageName := packageName.value,
   dockerBaseImage := "advancedtelematic/alpine-jre:adoptopenjdk-jdk8u222",
-  dockerUpdateLatest := false,
+  dockerUpdateLatest := true,
   dockerAliases ++= Seq(dockerAlias.value.withTag(git.formattedShaVersion.value)),
   dockerCommands ++= Seq(
     Cmd("USER", "root"),


### PR DESCRIPTION
Some systems need to know what is the latest container version. For
example HAT deployments.

CI using gitlab no longer pushes `artifacts.txt` to S3 as teamcity
did. So we need to push this tag to `:latest` so that services can use
the `latest` tag.