### PR TITLE
Remove param to filter not activated devices.

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -109,7 +109,6 @@ class DevicesResource(
       'groupType.as[GroupType].?,
       'groupId.as[GroupId].?,
       'nameContains.as[String].?,
-      'activated.as[Boolean].?,
       'sortBy.as[SortBy].?,
       'offset.as[Long].?,
       'limit.as[Long].?)).as(SearchParams)

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -68,7 +68,6 @@ object DataType {
                                 groupType: Option[GroupType],
                                 groupId: Option[GroupId],
                                 nameContains: Option[String],
-                                activated: Option[Boolean],
                                 sortBy: Option[SortBy],
                                 offset: Option[Long],
                                 limit: Option[Long],
@@ -76,7 +75,6 @@ object DataType {
     if (oemId.isDefined) {
       require(groupId.isEmpty, "Invalid parameters: groupId must be empty when searching by deviceId.")
       require(nameContains.isEmpty, "Invalid parameters: nameContains must be empty when searching by deviceId.")
-      require(activated.isEmpty, "Invalid parameters: activated must be empty when searching by deviceId.")
     }
   }
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/DeviceRepository.scala
@@ -169,30 +169,23 @@ object DeviceRepository {
   def search(ns: Namespace, params: SearchParams)(implicit ec: ExecutionContext): DBIO[PaginationResult[Device]] = {
     val query = params match {
 
-      case SearchParams(Some(oemId), _, _, None, None, None, _, _, _) =>
+      case SearchParams(Some(oemId), _, _, None, None, _, _, _) =>
         findByDeviceIdQuery(ns, oemId)
 
-      case SearchParams(None, Some(true), gt, None, nameContains, _, _, _, _) =>
+      case SearchParams(None, Some(true), gt, None, nameContains, _, _, _) =>
         runQueryFilteringByName(ns, groupedDevicesQuery(gt), nameContains)
 
-      case SearchParams(None, Some(false), gt, None, nameContains, _, _, _, _) =>
+      case SearchParams(None, Some(false), gt, None, nameContains, _, _, _) =>
         val ungroupedDevicesQuery = devices.filterNot(_.uuid.in(groupedDevicesQuery(gt).map(_.uuid)))
         runQueryFilteringByName(ns, ungroupedDevicesQuery, nameContains)
 
-      case SearchParams(None, _, _, gid, nameContains, _, _, _, _) =>
+      case SearchParams(None, _, _, gid, nameContains, _, _, _) =>
         searchQuery(ns, nameContains, gid)
 
       case _ => throw new IllegalArgumentException("Invalid parameter combination.")
     }
 
     query
-      .filter { dt =>
-        params.activated match {
-          case None => true.bind
-          case Some(true) => dt.activatedAt.isDefined
-          case Some(false) => dt.activatedAt.isEmpty
-        }
-      }
       .sortBy(params.sortBy.getOrElse(SortBy.Name))
       .paginateResult(params.offset.orDefaultOffset, params.limit.orDefaultLimit)
   }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -68,12 +68,10 @@ trait DeviceRequests { self: ResourceSpec =>
   def fetchByDeviceId(deviceId: DeviceOemId,
                       nameContains: Option[String] = None,
                       groupId: Option[GroupId] = None,
-                      activated: Option[Boolean] = None,
                      ): HttpRequest = {
     val m = ("deviceId" -> deviceId.show) +: Seq(
       nameContains.map("nameContains" -> _),
       groupId.map("groupId" -> _.show),
-      activated.map("activated" -> _.toString),
     ).collect { case Some(a) => a }
     Get(Resource.uri(api).withQuery(Query(m.toMap)))
   }
@@ -95,9 +93,6 @@ trait DeviceRequests { self: ResourceSpec =>
           Query("grouped" -> "false", "offset" -> offset.toString, "limit" -> limit.toString)
         )
     )
-
-  def fetchNotActivated: HttpRequest =
-    Get(Resource.uri(api).withQuery(Query("activated" -> "false", "limit" -> 500.toString)))
 
   def updateDevice(uuid: DeviceId, newName: DeviceName)(implicit ec: ExecutionContext): HttpRequest =
     Put(Resource.uri(api, uuid.show), UpdateDevice(newName))


### PR DESCRIPTION
It seems listing non-activated devices was not a very useful use-case after all. Now we want to show the devices that have not connected in the last X hours (OTA-4035).
This `activated` param has not been used in the end and there is no plan to use it, so I think it's better to remove it and clean-up before we introduce a new param to search by not-seen in the last hours.