### PR TITLE
Implement first version of public API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val `ota-device-registry` =
       libraryDependencies += "org.tpolecat" %% "atto-core" % "0.7.1"
     )
     .settings(libraryDependencies ++= library.libAts)
+    .settings(libraryDependencies += "com.advancedtelematic" %% "libtuf-server" % "0.7.0-59-gf6013d6")
     .settings(dependencyOverrides += library.kafkaClient)
 
 // *****************************************************************************

--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -23,13 +23,15 @@ info:
 
     The token will expire every 24 hours. The user needs to request a new token before the current token expires to continue using the api
 
-  version: "1.0.0"
-  title: "HERE OTA API"
+  version: 1.0.0-alpha
+  title: HERE OTA API
 servers:
   - url: http://api.ota.here.com/v1alpha
     description: production
   - url: https://ota-api-gateway-sit.borg-rd.nw.ops.here.com/v1alpha
     description: sit
+  - url: /v1alpha
+    description: this instance
   - url: "{uri}"
     description: custom
     variables:
@@ -44,9 +46,9 @@ paths:
   /devices:
     get:
       tags:
-        - "devices"
-      summary: "Returns all devices for the current account"
-      description: "Paginated list of devices"
+        - devices
+      summary: Returns all devices for the current account
+      description: Paginated list of devices
       parameters:
         - in: query
           name: oemId
@@ -63,7 +65,7 @@ paths:
             type: integer
       responses:
         200:
-          description: "successful operation"
+          description: successful operation
           content:
             application/json:
               schema:
@@ -74,26 +76,26 @@ paths:
   /devices/{deviceId}:
     get:
       tags:
-        - "devices"
-      summary: "Find device by ID"
-      description: "Returns a single device"
+        - devices
+      summary: Find device by ID"
+      description: Returns a single device
       parameters:
-        - name: "deviceId"
-          in: "path"
-          description: "ID of device to return"
+        - name: deviceId
+          in: path
+          description: ID of device to return
           required: true
           schema:
-            type: "string"
-            format: "uuid"
+            type: string
+            format: uuid
       responses:
         200:
-          description: "information about the device"
+          description: information about the device
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Device"
         404:
-          description: "Device not found"
+          description: Device not found
         401:
           $ref: '#/components/responses/UnauthorizedError'
 
@@ -105,48 +107,48 @@ components:
       bearerFormat: JWT
   schemas:
     SimplifiedDevice:
-      type: "object"
+      type: object
       required:
-      - "id"
-      - "oemId"
+      - id
+      - oemId
       properties:
         id:
-          type: "string"
-          format: "uuid"
+          type: string
+          format: uuid
         oemId:
-          type: "string"
-          format: "string"
+          type: string
+          format: string
 
     PaginationResponseDevice:
-      type: "object"
+      type: object
       properties:
         total:
-          type: "integer"
-          format: "int64"
+          type: integer
+          format: int64
         offset:
-          type: "integer"
-          format: "int64"
+          type: integer
+          format: int64
         values:
-          type: "array"
+          type: array
           items:
             $ref: "#/components/schemas/SimplifiedDevice"
 
     Device:
-      type: "object"
+      type: object
       required: [id, oemId, name, status]
       properties:
         id:
-          type: "string"
-          format: "uuid"
+          type: string
+          format: uuid
         oemId:
-          type: "string"
-          format: "string"
+          type: string
+          format: string
         name:
-          type: "string"
-          format: "string"
+          type: string
+          format: string
         lastSeen:
-          type: "string"
-          format: "date-time"
+          type: string
+          format: date-time
         primaryEcu:
           type: object
           required: [ecuId, installedTarget]
@@ -177,7 +179,7 @@ components:
                       required: [sha256]
         status:
           type: string
-          description: "current status of device"
+          description: current status of device
           enum:
           - NotSeen
           - Error

--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -30,11 +30,11 @@ servers:
     description: production
   - url: https://ota-api-gateway-sit.borg-rd.nw.ops.here.com/v1alpha
     description: sit
-  - url: "{uri}/api/v1alpha"
+  - url: "{uri}"
     description: custom
     variables:
       uri:
-        default: /api-provider
+        default: http://localhost/v1alpha
         description: full uri to api
 
 security:
@@ -48,6 +48,11 @@ paths:
       summary: "Returns all devices for the current account"
       description: "Paginated list of devices"
       parameters:
+        - in: query
+          name: oemId
+          description: the id used by the OEM to provision the device
+          schema:
+            type: string
         - in: query
           name: limit
           schema:

--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -1,0 +1,184 @@
+openapi: 3.0.0
+info:
+  description: |
+    HERE OTA API for device information
+
+    This api uses a Bearer token for authentication. To obtain a bearer token download a credentials.zip from the HERE OTA UI and extract `treehub.json`.
+
+    To obtain a valid Bearer token you can use HTTP:
+
+    ```
+    curl -X POST <auth-plus-url>/token -d "grant_type=client_credentials" \
+      -u <client-id>:<client-secret> |
+      jq -r .access_token
+    ````
+
+    `auth-plus-url`, `client-id` and `client-secret` are included in `treehub.json`.
+
+    This access token can be used to access this api:
+
+    ```
+    curl -H 'Authorization: Bearer $token' https://this-api-url/v1/devices
+    ```
+
+    The token will expire every 24 hours. The user needs to request a new token before the current token expires to continue using the api
+
+  version: "1.0.0"
+  title: "HERE OTA API"
+servers:
+  - url: http://api.ota.here.com/v1
+    description: production
+  - url: https://ota-api-gateway-sit.borg-rd.nw.ops.here.com/v1
+    description: sit
+  - url: "{uri}/api/v1"
+    description: custom
+    variables:
+      uri:
+        default: /api-provider
+        description: full uri to api
+
+security:
+  - bearerAuth: []
+
+paths:
+  /devices:
+    get:
+      tags:
+        - "devices"
+      summary: "Returns all devices for the current account"
+      description: "Paginated list of devices"
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        200:
+          description: "successful operation"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginationResponseDevice"
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+
+  /devices/{deviceId}:
+    get:
+      tags:
+        - "devices"
+      summary: "Find device by ID"
+      description: "Returns a single device"
+      parameters:
+        - name: "deviceId"
+          in: "path"
+          description: "ID of device to return"
+          required: true
+          schema:
+            type: "string"
+            format: "uuid"
+      responses:
+        200:
+          description: "information about the device"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Device"
+        404:
+          description: "Device not found"
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+    SimplifiedDevice:
+      type: "object"
+      required:
+      - "id"
+      - "oemId"
+      properties:
+        id:
+          type: "string"
+          format: "uuid"
+        oemId:
+          type: "string"
+          format: "string"
+
+    PaginationResponseDevice:
+      type: "object"
+      properties:
+        total:
+          type: "integer"
+          format: "int64"
+        offset:
+          type: "integer"
+          format: "int64"
+        values:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/SimplifiedDevice"
+
+    Device:
+      type: "object"
+      required: [id, oemId, name, status]
+      properties:
+        id:
+          type: "string"
+          format: "uuid"
+        oemId:
+          type: "string"
+          format: "string"
+        name:
+          type: "string"
+          format: "string"
+        lastSeen:
+          type: "string"
+          format: "date-time"
+        primaryEcu:
+          type: object
+          required: [ecuId, installedTarget]
+          properties:
+            ecuId:
+              type: string
+              format: string
+            installedTarget:
+              type: object
+              required: [filename, target]
+              properties:
+                filename:
+                  type: string
+                  format: string
+                target:
+                  type: object
+                  properties:
+                    length:
+                      type: integer
+                    hashes:
+                      type: object
+                      properties:
+                        sha256:
+                          type: string
+                          format: string
+                          minLength: 64
+                          maxLength: 64
+                      required: [sha256]
+        status:
+          type: string
+          description: "current status of device"
+          enum:
+          - NotSeen
+          - Error
+          - UpToDate
+          - Outdated
+
+  responses:
+    UnauthorizedError:
+      description: Access token is missing or invalid

--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -18,7 +18,7 @@ info:
     This access token can be used to access this api:
 
     ```
-    curl -H 'Authorization: Bearer $token' https://this-api-url/v1/devices
+    curl -H 'Authorization: Bearer $token' https://this-api-url/v1alpha/devices
     ```
 
     The token will expire every 24 hours. The user needs to request a new token before the current token expires to continue using the api
@@ -26,11 +26,11 @@ info:
   version: "1.0.0"
   title: "HERE OTA API"
 servers:
-  - url: http://api.ota.here.com/v1
+  - url: http://api.ota.here.com/v1alpha
     description: production
-  - url: https://ota-api-gateway-sit.borg-rd.nw.ops.here.com/v1
+  - url: https://ota-api-gateway-sit.borg-rd.nw.ops.here.com/v1alpha
     description: sit
-  - url: "{uri}/api/v1"
+  - url: "{uri}/api/v1alpha"
     description: custom
     variables:
       uri:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -17,6 +17,17 @@ auth = {
   protocol = ${?AUTH_PROTOCOL}
 }
 
+director = {
+  host = "localhost"
+  host = ${?DIRECTOR_HOST}
+  port = 9001
+  port = ${?DIRECTOR_PORT}
+  scheme = "http"
+  scheme = ${?DIRECTOR_SCHEME}
+  uri = ${director.scheme}"://"${?director.host}":"${?director.port}
+  uri = ${?DIRECTOR_URI}
+}
+
 scopes = {
   domain = ""
   domain = ${?SCOPES_DOMAIN}

--- a/src/main/resources/swagger.html
+++ b/src/main/resources/swagger.html
@@ -1,0 +1,61 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="http://unpkg.com/swagger-ui-dist@3/swagger-ui.css" >
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+</head>
+
+<script src="http://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+<script src="http://unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js"></script>
+
+<body>
+<div id="swagger-ui"></div>
+
+<script>
+    window.onload = function() {
+      var baseUrl = location.protocol+'//'+location.hostname+(location.port ? ':'+location.port: '');
+
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: baseUrl + "/api-provider/docs/definition.yml",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+      // End Swagger UI call region
+
+      window.ui = ui
+    }
+  </script>
+</body>
+</html>

--- a/src/main/resources/swagger.html
+++ b/src/main/resources/swagger.html
@@ -40,7 +40,7 @@
 
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: baseUrl + "/api-provider/docs/definition.yml",
+        url: baseUrl + "/docs/definition.yml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/client/DirectorClient.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/client/DirectorClient.scala
@@ -1,0 +1,56 @@
+package com.advancedtelematic.ota.api_provider.client
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.Uri.Path.Slash
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, Uri}
+import akka.stream.Materializer
+import com.advancedtelematic.libats.data.DataType.{Namespace, ValidChecksum}
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.libats.http.tracing.Tracing.ServerRequestTracing
+import com.advancedtelematic.libats.http.tracing.TracingHttpClient
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, TargetFilename}
+import com.advancedtelematic.ota.api_provider.client.DirectorClient.EcuInfoResponse
+import eu.timepit.refined.api.Refined
+import io.circe.Codec
+import io.circe.generic.semiauto._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object DirectorClient {
+  // TODO: This Comes from director, should be abstract somewhere. director-lite ?
+  final case class Hashes(sha256: Refined[String, ValidChecksum])
+  final case class EcuInfoImage(filepath: TargetFilename, size: Long, hash: Hashes)
+  final case class EcuInfoResponse(id: EcuIdentifier, hardwareId: HardwareIdentifier, primary: Boolean, image: EcuInfoImage)
+
+  import com.advancedtelematic.libtuf.data.ClientCodecs._
+  import com.advancedtelematic.libtuf.data.TufCodecs._
+  import com.advancedtelematic.libats.codecs.CirceRefined._
+
+  implicit val hashesCodec: Codec[Hashes] = deriveCodec
+  implicit val ecuInfoImageCodec: Codec[EcuInfoImage] = deriveCodec
+  implicit val ecuInfoResponseCodec: Codec[EcuInfoResponse] = deriveCodec
+}
+
+trait DirectorClient {
+  def fetchDeviceEcus(ns: Namespace, deviceId: DeviceId): Future[Seq[EcuInfoResponse]]
+}
+
+class DirectorHttpClient(directorUri: Uri,
+                         httpClient: HttpRequest => Future[HttpResponse])
+                        (implicit ec: ExecutionContext, system: ActorSystem, mat: Materializer, tracing: ServerRequestTracing)
+  extends TracingHttpClient(httpClient, "director") with DirectorClient {
+
+  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+  import DirectorClient._
+
+  private def apiUri(path: Path) = directorUri.withPath(Path("/api") / "v1" ++ Slash(path))
+
+  override def fetchDeviceEcus(ns: Namespace, deviceId: DeviceId): Future[Seq[EcuInfoResponse]] = {
+    val req = HttpRequest(HttpMethods.GET, uri = apiUri(Path(s"admin/v1/${deviceId.uuid.toString}"))).withHeaders(RawHeader("x-ats-namespace", ns.get))
+
+    execHttp[Seq[EcuInfoResponse]](req)()
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/data/DataType.scala
@@ -1,0 +1,42 @@
+package com.advancedtelematic.ota.api_provider.data
+
+import java.time.Instant
+
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libtuf.data.ClientDataType.ClientTargetItem
+import com.advancedtelematic.libtuf.data.TufDataType.TargetFilename
+import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
+import com.advancedtelematic.ota.deviceregistry.data.DeviceName
+import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus.DeviceStatus
+import com.advancedtelematic.libats.codecs.CirceCodecs._
+import com.advancedtelematic.libtuf.data.ClientCodecs._
+import com.advancedtelematic.libtuf.data.TufCodecs._
+import com.advancedtelematic.ota.deviceregistry.data.Codecs._
+import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId._
+
+object DataType {
+
+  import io.circe.generic.semiauto._
+
+  case class InstalledTarget(filename: TargetFilename, target: ClientTargetItem)
+
+  case class PrimaryEcu(ecuId: EcuIdentifier, installedTarget: InstalledTarget)
+
+  case class ListingDevice(id: DeviceId, oemId: DeviceOemId)
+
+  case class ApiDevice(oemId: DeviceOemId,
+                       id: DeviceId,
+                       name: DeviceName,
+                       lastSeen: Option[Instant],
+                       status: DeviceStatus,
+                       primaryEcu: Option[PrimaryEcu])
+
+  implicit val installedTargetCodec = deriveCodec[InstalledTarget]
+
+  implicit val primaryEcuCodec = deriveCodec[PrimaryEcu]
+
+  implicit val apiDeviceCodec = deriveCodec[ApiDevice]
+
+  implicit val listingDeviceCodec = deriveCodec[ListingDevice]
+}

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/data/DataType.scala
@@ -14,6 +14,7 @@ import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId._
+import JsonDropNullValues._
 
 object DataType {
 
@@ -34,7 +35,8 @@ object DataType {
 
   implicit val installedTargetCodec = deriveCodec[InstalledTarget]
 
-  implicit val primaryEcuCodec = deriveCodec[PrimaryEcu]
+  implicit val primaryEcuEncoder = deriveEncoder[PrimaryEcu].mapJson(_.dropNullValuesDeep)
+  implicit val primaryEcuDecoder = deriveDecoder[PrimaryEcu]
 
   implicit val apiDeviceCodec = deriveCodec[ApiDevice]
 

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/data/JsonDropNullValues.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/data/JsonDropNullValues.scala
@@ -1,0 +1,21 @@
+package com.advancedtelematic.ota.api_provider.data
+
+import io.circe.Json
+
+object JsonDropNullValues {
+  implicit class JsonDropNullValuesConversion(value: Json) {
+    private def rec(counter: Int)(json: Json): Json = {
+      if (counter == 0)
+        json
+      else
+        json.arrayOrObject[Json](
+          json,
+          array => Json.fromValues(array.map(rec(counter - 1))),
+          obj => Json.fromJsonObject(obj.filter { case (_, v) => !v.isNull }.mapValues(rec(counter - 1)))
+        )
+    }
+
+    // Drops values recursively, limited to 5 levels
+    def dropNullValuesDeep: Json = rec(5)(value)
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiDocsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiDocsResource.scala
@@ -1,0 +1,19 @@
+package com.advancedtelematic.ota.api_provider.http
+
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.server.{Directives, Route}
+
+class ApiDocsResource {
+  import Directives._
+
+  val route: Route = {
+    pathPrefix("docs") {
+      path("definition.yml") {
+        getFromResource("api-definition.yml", ContentTypes.`text/plain(UTF-8)`)
+      } ~
+      pathEnd {
+        getFromResource("swagger.html", ContentTypes.`text/html(UTF-8)`)
+      }
+    }
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
@@ -8,6 +8,7 @@ import com.advancedtelematic.ota.api_provider.client.DirectorClient
 import com.advancedtelematic.ota.api_provider.data.DataType.{ApiDevice, InstalledTarget, ListingDevice, PrimaryEcu}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.SearchParams
 import com.advancedtelematic.ota.deviceregistry.data.Device
+import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
 import org.slf4j.LoggerFactory
 import slick.jdbc.MySQLProfile.api._
@@ -39,8 +40,8 @@ class ApiProvider(directorClient: DirectorClient)(implicit ec: ExecutionContext,
     localInfo.toApi(primaryEcuInfo)
   }
 
-  def allDevices(ns: Namespace, limit: Option[Long], offset: Option[Long]): Future[PaginationResult[ListingDevice]] = {
-    val f = db.run(DeviceRepository.search(ns, SearchParams.all(limit, offset)))
+  def allDevices(ns: Namespace, oemId: Option[DeviceOemId], limit: Option[Long], offset: Option[Long]): Future[PaginationResult[ListingDevice]] = {
+    val f = db.run(DeviceRepository.search(ns, SearchParams.all(limit, offset).copy(oemId = oemId)))
     f.map(_.map { device =>
       ListingDevice(device.uuid, device.deviceId)
     })

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
@@ -1,0 +1,48 @@
+package com.advancedtelematic.ota.api_provider.http
+
+import com.advancedtelematic.libats.data.DataType.{HashMethod, Namespace}
+import com.advancedtelematic.libats.data.PaginationResult
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.libtuf.data.ClientDataType.{ClientHashes, ClientTargetItem}
+import com.advancedtelematic.ota.api_provider.client.DirectorClient
+import com.advancedtelematic.ota.api_provider.data.DataType.{ApiDevice, InstalledTarget, ListingDevice, PrimaryEcu}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.SearchParams
+import com.advancedtelematic.ota.deviceregistry.data.Device
+import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
+import org.slf4j.LoggerFactory
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ApiProvider(directorClient: DirectorClient)(implicit ec: ExecutionContext, db: Database) {
+
+  private val _log = LoggerFactory.getLogger(this.getClass)
+
+  implicit class DeviceToApiTranslation(device: Device) {
+    def toApi(primaryEcu: Option[PrimaryEcu]): ApiDevice =
+      ApiDevice(device.deviceId, device.uuid, device.deviceName, device.lastSeen, device.deviceStatus, primaryEcu: Option[PrimaryEcu])
+  }
+
+  def findDevice(ns: Namespace, deviceId: DeviceId): Future[ApiDevice] = for {
+   localInfo <- db.run(DeviceRepository.findByUuid(deviceId))
+   directorInfo <- directorClient.fetchDeviceEcus(ns, deviceId)
+  } yield {
+    val primaryEcuInfo = directorInfo.find(_.primary).map { ecuInfo =>
+      val hashes = Map(HashMethod.SHA256 -> ecuInfo.image.hash.sha256)
+      PrimaryEcu(ecuInfo.id, InstalledTarget(ecuInfo.image.filepath, ClientTargetItem(hashes, ecuInfo.image.size, custom = None)))
+    }
+
+    if(primaryEcuInfo.isEmpty) {
+      _log.warn(s"Could not get primary ecu for $deviceId from director")
+    }
+
+    localInfo.toApi(primaryEcuInfo)
+  }
+
+  def allDevices(ns: Namespace, limit: Option[Long], offset: Option[Long]): Future[PaginationResult[ListingDevice]] = {
+    val f = db.run(DeviceRepository.search(ns, SearchParams.all(limit, offset)))
+    f.map(_.map { device =>
+      ListingDevice(device.uuid, device.deviceId)
+    })
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProviderRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProviderRoutes.scala
@@ -1,11 +1,7 @@
 package com.advancedtelematic.ota.api_provider.http
 
-import java.nio.file.Paths
-
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.server.ContentNegotiator.Alternative.ContentType
 import akka.http.scaladsl.server.{Directive1, Directives, Route}
 import akka.stream.ActorMaterializer
 import com.advancedtelematic.libats.auth.AuthedNamespaceScope
@@ -16,20 +12,6 @@ import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.ExecutionContext
 
-class ApiDocsResource {
-  import Directives._
-
-  val route: Route = {
-    pathPrefix("docs") {
-      path("definition.yml") {
-        getFromResource("api-definition.yml", ContentTypes.`text/plain(UTF-8)`)
-      } ~
-      pathEnd {
-        getFromResource("swagger.html", ContentTypes.`text/html(UTF-8)`)
-      }
-    }
-  }
-}
 
 class ApiProviderRoutes(namespaceExtractor: Directive1[AuthedNamespaceScope],
                         deviceNamespaceAuthorizer: Directive1[DeviceId],

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProviderRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProviderRoutes.scala
@@ -1,0 +1,36 @@
+package com.advancedtelematic.ota.api_provider.http
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.{Directive1, Directives, Route}
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.libats.auth.AuthedNamespaceScope
+import com.advancedtelematic.libats.http.{DefaultRejectionHandler, ErrorHandler}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.api_provider.client.DirectorClient
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.ExecutionContext
+
+class ApiProviderRoutes(namespaceExtractor: Directive1[AuthedNamespaceScope],
+                        deviceNamespaceAuthorizer: Directive1[DeviceId],
+                        directorClient: DirectorClient)
+                       (implicit db: Database, system: ActorSystem, mat: ActorMaterializer, exec: ExecutionContext) {
+
+  import akka.http.scaladsl.server.Directives._
+
+  val withVersionHeaders = {
+    val header = RawHeader("x-here-ota-api-provider-version", s"api-provider@device-registry")
+    Directives.respondWithHeader(header)
+  }
+
+  val route: Route = withVersionHeaders {
+    pathPrefix("api-provider" / "api" / "v1") {
+      handleRejections(DefaultRejectionHandler.rejectionHandler) {
+        ErrorHandler.handleErrors {
+          new DeviceInfoResource(namespaceExtractor, deviceNamespaceAuthorizer, directorClient).route
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProviderRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProviderRoutes.scala
@@ -45,7 +45,7 @@ class ApiProviderRoutes(namespaceExtractor: Directive1[AuthedNamespaceScope],
 
   val route: Route = withVersionHeaders {
     pathPrefix("api-provider") {
-      pathPrefix ("api" / "v1") {
+      pathPrefix ("api" / "v1alpha") {
         handleRejections(DefaultRejectionHandler.rejectionHandler) {
           ErrorHandler.handleErrors {
             new DeviceInfoResource(namespaceExtractor, deviceNamespaceAuthorizer, directorClient).route

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResource.scala
@@ -1,0 +1,36 @@
+package com.advancedtelematic.ota.api_provider.http
+
+import akka.http.scaladsl.server.{Directive1, Route}
+import com.advancedtelematic.libats.auth.AuthedNamespaceScope
+import com.advancedtelematic.libats.data.PaginationResult
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.api_provider.client.DirectorClient
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.ExecutionContext
+
+class DeviceInfoResource(namespaceExtractor: Directive1[AuthedNamespaceScope],
+                         deviceNamespaceAuthorizer: Directive1[DeviceId],
+                         directorClient: DirectorClient)
+                        (implicit ec: ExecutionContext, db: Database) {
+  import PaginationResult._
+  import akka.http.scaladsl.server.Directives._
+
+  val apiProvider = new ApiProvider(directorClient)
+
+  val route: Route = namespaceExtractor { ns =>
+    pathPrefix("devices") {
+      (get & pathEnd & parameters('offset.as[Long].?, 'limit.as[Long].?))  { (offset, limit) =>
+        val f = apiProvider.allDevices(ns.namespace, offset, limit)
+        complete(f)
+      } ~
+      deviceNamespaceAuthorizer { deviceId =>
+        (get & pathEnd) {
+          val f = apiProvider.findDevice(ns.namespace, deviceId)
+          complete(f)
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResource.scala
@@ -5,8 +5,10 @@ import com.advancedtelematic.libats.auth.AuthedNamespaceScope
 import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.ota.api_provider.client.DirectorClient
+import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import slick.jdbc.MySQLProfile.api._
+import com.advancedtelematic.libats.http.AnyvalMarshallingSupport._
 
 import scala.concurrent.ExecutionContext
 
@@ -21,8 +23,8 @@ class DeviceInfoResource(namespaceExtractor: Directive1[AuthedNamespaceScope],
 
   val route: Route = namespaceExtractor { ns =>
     pathPrefix("devices") {
-      (get & pathEnd & parameters('offset.as[Long].?, 'limit.as[Long].?))  { (offset, limit) =>
-        val f = apiProvider.allDevices(ns.namespace, offset, limit)
+      (get & pathEnd & parameters(('oemId.as[DeviceOemId].?, 'offset.as[Long].?, 'limit.as[Long].?)))  { (oemId, offset, limit) =>
+        val f = apiProvider.allDevices(ns.namespace, oemId, offset, limit)
         complete(f)
       } ~
       deviceNamespaceAuthorizer { deviceId =>

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceRegistryRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceRegistryRoutes.scala
@@ -1,0 +1,39 @@
+package com.advancedtelematic.ota.deviceregistry
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.{Directive1, Directives, Route}
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.libats.auth.AuthedNamespaceScope
+import com.advancedtelematic.libats.http.DefaultRejectionHandler.rejectionHandler
+import com.advancedtelematic.libats.http.ErrorHandler
+import com.advancedtelematic.libats.messaging.MessageBusPublisher
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.api_provider.client.DirectorClient
+import com.advancedtelematic.ota.api_provider.http.ApiProviderRoutes
+
+import scala.concurrent.ExecutionContext
+import slick.jdbc.MySQLProfile.api._
+
+/**
+  * Base API routing class.
+  */
+class DeviceRegistryRoutes(
+    namespaceExtractor: Directive1[AuthedNamespaceScope],
+    deviceNamespaceAuthorizer: Directive1[DeviceId],
+    messageBus: MessageBusPublisher,
+    directorClient: DirectorClient
+)(implicit db: Database, system: ActorSystem, mat: ActorMaterializer, exec: ExecutionContext)
+    extends Directives {
+
+  val route: Route =
+    pathPrefix("api" / "v1") {
+      handleRejections(rejectionHandler) {
+        ErrorHandler.handleErrors {
+          new DevicesResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
+          new SystemInfoResource(messageBus, namespaceExtractor, deviceNamespaceAuthorizer).route ~
+          new PublicCredentialsResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
+          new GroupsResource(namespaceExtractor, deviceNamespaceAuthorizer).route
+      }
+    }
+  } ~
+      new ApiProviderRoutes(namespaceExtractor, deviceNamespaceAuthorizer, directorClient).route
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DevicesResource.scala
@@ -112,7 +112,7 @@ class DevicesResource(
       'notSeenSinceHours.as[Int].?,
       'sortBy.as[SortBy].?,
       'offset.as[Long].?,
-      'limit.as[Long].?)).as(SearchParams)
+      'limit.as[Long].?)).as(SearchParams.apply _)
     { params => complete(db.run(DeviceRepository.search(ns, params))) }
 
   def createDevice(ns: Namespace, device: DeviceT): Route = {

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -63,6 +63,20 @@ object DataType {
   final case class DeviceInstallationResult(correlationId: CorrelationId, resultCode: ResultCode, deviceId: DeviceId, success: Boolean, receivedAt: Instant, installationReport: Json)
   final case class EcuInstallationResult(correlationId: CorrelationId, resultCode: ResultCode, deviceId: DeviceId, ecuId: EcuIdentifier, success: Boolean)
 
+  object SearchParams {
+    def all(limit: Option[Long], offset: Option[Long]) = SearchParams(
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some(SortBy.CreatedAt),
+      offset,
+      limit
+    )
+  }
+
   final case class SearchParams(oemId: Option[DeviceOemId],
                                 grouped: Option[Boolean],
                                 groupType: Option[GroupType],

--- a/src/test/scala/com/advancedtelematic/ota/api_provider/http/ApiDocsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/api_provider/http/ApiDocsResourceSpec.scala
@@ -1,0 +1,22 @@
+package com.advancedtelematic.ota.api_provider.http
+
+import akka.http.scaladsl.model.StatusCodes
+import com.advancedtelematic.ota.deviceregistry.{DeviceRequests, ResourceSpec}
+import org.scalatest.FunSuite
+import org.scalatest.concurrent.Eventually
+
+
+class ApiDocsResourceSpec extends FunSuite with ResourceSpec with Eventually with DeviceRequests {
+
+  test("returns yml definition file") {
+    Get("/api-provider/docs/definition.yml")  ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  test("returns swagger file") {
+    Get("/api-provider/docs")  ~> route ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+}

--- a/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
@@ -1,0 +1,81 @@
+package com.advancedtelematic.ota.api_provider.http
+
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import com.advancedtelematic.libats.data.{EcuIdentifier, PaginationResult}
+import com.advancedtelematic.ota.deviceregistry.{DeviceRequests, ResourceSpec}
+import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus
+import org.scalatest.FunSuite
+import org.scalatest.concurrent.Eventually
+import com.advancedtelematic.ota.deviceregistry.data.GeneratorOps._
+import cats.syntax.show._
+import cats.syntax.either._
+import com.advancedtelematic.libats.data.DataType.ValidChecksum
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId._
+import com.advancedtelematic.libtuf.data.TufDataType.{ValidHardwareIdentifier, ValidTargetFilename}
+import com.advancedtelematic.ota.api_provider.client.DirectorClient.{EcuInfoImage, Hashes}
+import com.advancedtelematic.libats.data.RefinedUtils.RefineTry
+
+class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually with DeviceRequests {
+
+  import com.advancedtelematic.ota.api_provider.data.DataType._
+
+  private def apiProviderUri(pathSuffixes: String*): Uri = {
+    val BasePath = Path("/api-provider") / "api" / "v1"
+    Uri.Empty.withPath(pathSuffixes.foldLeft(BasePath)(_ / _))
+  }
+
+  test("sets different provider version header") {
+    Get(apiProviderUri("devices"))  ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      response.headers.find(_.is("x-here-ota-api-provider-version")).map(_.value()) should contain("api-provider@device-registry")
+    }
+  }
+
+  test("list devices, paginated") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    createDeviceOk(device)
+
+    Get(apiProviderUri("devices"))  ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val pages = responseAs[PaginationResult[ListingDevice]]
+
+      pages.limit shouldBe 50
+      pages.offset shouldBe 0
+      pages.total shouldBe 1
+
+      val first = pages.values.head
+
+      first shouldBe ListingDevice(device.uuid.get, device.deviceId)
+    }
+  }
+
+  test("gets information for a device") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+
+    val ecuId = EcuIdentifier("somefakeid").valueOr(throw _)
+    val hardwareIdentifier = "fakehwid".refineTry[ValidHardwareIdentifier].get
+    val targetFilename = "some-hash".refineTry[ValidTargetFilename].get
+    val hash = "848cba347e8a37330b97835936dd4f846291739d0d5efa9eb10c75e4c15ba87a".refineTry[ValidChecksum].get
+    val image = EcuInfoImage(targetFilename, 2222, Hashes(hash))
+
+    directorClient.addDevice(deviceId, ecuId, hardwareIdentifier, image)
+
+    Get(apiProviderUri("devices", deviceId.show))  ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val apiDevice = responseAs[ApiDevice]
+      apiDevice.oemId shouldBe device.deviceId
+      apiDevice.id shouldBe device.uuid.get
+      apiDevice.lastSeen shouldBe None
+      apiDevice.status shouldBe DeviceStatus.NotSeen
+
+      apiDevice.primaryEcu shouldBe defined
+      apiDevice.primaryEcu.map(_.ecuId) should contain(ecuId)
+      apiDevice.primaryEcu.map(_.installedTarget.filename) should contain(targetFilename)
+      apiDevice.primaryEcu.map(_.installedTarget.target.length) should contain(2222)
+      apiDevice.primaryEcu.map(_.installedTarget.target.hashes.head._2) should contain(hash)
+    }
+  }
+}

--- a/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
@@ -22,7 +22,7 @@ class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually 
   import com.advancedtelematic.ota.api_provider.data.DataType._
 
   private def apiProviderUri(pathSuffixes: String*): Uri = {
-    val BasePath = Path("/api-provider") / "api" / "v1"
+    val BasePath = Path("/api-provider") / "api" / "v1alpha"
     Uri.Empty.withPath(pathSuffixes.foldLeft(BasePath)(_ / _))
   }
 


### PR DESCRIPTION
This is implemented as a separate resource and routes as it would be easier to extract and verify on code reviews.

We keep this in this in device-registry, rather than create a new service for this, so that we can provide an api to the users as soon as possible without going through setting up deployment descriptors and ota-charts. Since delivering something to the client by the end of the current sprint is a hard requirement from product, we have no choice here.

Unfortunately this means that device-registry now contacts director. We must be careful to not use this code from anywhere else in device-registry.

We are including `libtuf-server` so we can reuse at least some of the data type to parse data coming from director.

charts need to be updated to include `DIRECTOR_HOST` and `DIRECTOR_PORT`, or device registry will not startup anymore.

The requirements for OTA-3977 mention only:

    For a given device id,
    1. Device status (UpToDate, Error, NotSeen, Outdated)

Which this change implements. However, the final user already requested implementation of:

          2. Pending Update and its associated status (Download
          started, Download completed, Installation started,
          Installation completed)

          3. Current installed OSTree image on primary (hash)

So this change also implements a first version for 3.