### PR TITLE
Do not run tests on deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,9 @@ test:
   stage: test
   tags:
     - docker-sock
+  except:
+    refs:
+      - deploy/sit
   services:
     - name: mariadb:10.2
       alias: db


### PR DESCRIPTION
Slightly controversial change. 

Tests are executed anyway when the image is built. If the image was not built (and the tests green) the deployment will fail, so why run the tests again?

