### PR TITLE
Fix the plural in the Device schema

### DIFF
--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -164,14 +164,14 @@ components:
               format: string
             installedSoftwareVersion:
               type: object
-              required: [filename, length, hashes]
+              required: [filename, length, hash]
               properties:
                 filename:
                   type: string
                   format: string
                 length:
                   type: integer
-                hashes:
+                hash:
                   type: object
                   required: [sha256]
                   properties:


### PR DESCRIPTION
Feedback from Spekulatius : remove plural from hashes as this is not an array, but a single value