### PR TITLE
Implement device queue and device events endpoints for public api

### DIFF
--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+qopenapi: 3.0.0
 info:
   description: |
     HERE OTA API for device information
@@ -105,6 +105,58 @@ paths:
         401:
           $ref: '#/components/responses/UnauthorizedError'
 
+
+  /devices/{uuid}/queue:
+    get:
+      tags:
+        - devices
+      description: Show the update queue for a device
+      parameters:
+        - name: uuid
+          in: path
+          description: ID of the device to return the queue
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: Queued updates for the device
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/QueueItem"
+
+  /devices/{uuid}/events:
+    get:
+      tags:
+        - devices
+      description: Show all events reported by a device, sorted by most recent first
+      parameters:
+        - name: uuid
+          in: path
+          description: ID of the device
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: updateId
+          in: query
+          description: Only return events that refer to this update
+          required: false
+          schema:
+            type: string
+            format: string
+      responses:
+        200:
+          description: A description of the current status of the update in this device
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceEvents"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -139,6 +191,84 @@ components:
           items:
             $ref: "#/components/schemas/SimplifiedDevice"
 
+    DeviceEvents:
+      type: object
+      properties:
+        deviceUuid:
+          type: string
+          format: uuid
+        events:
+          type: array
+          items:
+            type: object
+            required: [name, receivedTime]
+            properties:
+              updateId:
+                type: string
+                format: string
+              ecuId:
+                type: string
+                format: string
+              name:
+                type: string
+                enum:
+                  - DownloadComplete
+                  - DownloadStarted
+                  - DownloadCompleted
+                  - InstallationStarted
+                  - InstallationApplied
+                  - InstallationCompleted
+                  - DevicePaused
+                  - DeviceResumed
+                  - Accepted
+                  - Declined
+                  - Postponed
+                  - InstallationComplete
+              receivedTime:
+                type: string
+                format: date-time
+              deviceTime:
+                type: string
+                format: date-time
+
+    QueueItem:
+      type: object
+      properties:
+        deviceUuid:
+          type: string
+          format: uuid
+        updateId:
+          type: string
+          format: string
+        ecus:
+          type: object
+          required: [ecuId, softwareVersion]
+          properties:
+            ecuId:
+              type: string
+              format: string
+            softwareVersion:
+              $ref: "#/components/schemas/SoftwareVersion"
+
+    SoftwareVersion:
+      type: object
+      required: [filename, length, hashes]
+      properties:
+        filename:
+          type: string
+          format: string
+        length:
+          type: integer
+        hashes:
+          type: object
+          required: [sha256]
+          properties:
+            sha256:
+              type: string
+              format: string
+              minLength: 64
+              maxLength: 64
+
     Device:
       type: object
       required: [uuid, deviceId, name, status]
@@ -163,23 +293,7 @@ components:
               type: string
               format: string
             installedSoftwareVersion:
-              type: object
-              required: [filename, length, hashes]
-              properties:
-                filename:
-                  type: string
-                  format: string
-                length:
-                  type: integer
-                hashes:
-                  type: object
-                  required: [sha256]
-                  properties:
-                    sha256:
-                      type: string
-                      format: string
-                      minLength: 64
-                      maxLength: 64
+              $ref: "#/components/schemas/SoftwareVersion"
 
         status:
           type: string

--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -157,7 +157,7 @@ components:
           format: date-time
         primaryEcu:
           type: object
-          required: [ecuId, installedSofwareVersion]
+          required: [ecuId, installedSoftwareVersion]
           properties:
             ecuId:
               type: string

--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -262,6 +262,8 @@ components:
         hashes:
           type: object
           required: [sha256]
+          description: A map containing the available checksums for this update. The key for each item is the
+            algorithm used to calculate the checksum defined in the value.
           properties:
             sha256:
               type: string

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/client/DirectorClient.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/client/DirectorClient.scala
@@ -7,28 +7,59 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, StatusCodes, Uri}
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.Materializer
-import com.advancedtelematic.libats.data.DataType.{Namespace, ValidChecksum}
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, HashMethod, Namespace, ValidChecksum}
 import com.advancedtelematic.libats.data.EcuIdentifier
 import com.advancedtelematic.libats.http.tracing.Tracing.ServerRequestTracing
 import com.advancedtelematic.libats.http.tracing.TracingHttpClient
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, TargetFilename}
-import com.advancedtelematic.ota.api_provider.client.DirectorClient.EcuInfoResponse
+import com.advancedtelematic.ota.api_provider.client.DirectorClient.{DirectorQueueItem, EcuInfoResponse}
 import eu.timepit.refined.api.Refined
-import io.circe.Codec
+import io.circe.{Codec, Json, KeyDecoder, KeyEncoder}
 import io.circe.generic.semiauto._
+import cats.implicits._
+import com.advancedtelematic.libats.codecs.CirceValidatedGeneric
+import com.advancedtelematic.libtuf.data.ClientDataType.ClientHashes
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.{ExecutionContext, Future}
 
+
 object DirectorClient {
   // TODO: This Comes from director, should be abstract somewhere. director-lite ?
-  final case class Hashes(sha256: Refined[String, ValidChecksum])
+  final case class Hashes(sha256: Refined[String, ValidChecksum]) {
+    def toClient: ClientHashes = Map(HashMethod.SHA256 -> sha256)
+  }
   final case class EcuInfoImage(filepath: TargetFilename, size: Long, hash: Hashes)
   final case class EcuInfoResponse(id: EcuIdentifier, hardwareId: HardwareIdentifier, primary: Boolean, image: EcuInfoImage)
 
   import com.advancedtelematic.libtuf.data.ClientCodecs._
   import com.advancedtelematic.libtuf.data.TufCodecs._
   import com.advancedtelematic.libats.codecs.CirceRefined._
+  import CorrelationId._
+  import EcuIdentifier._
+
+  final case class DirectorQueueItem(correlationId: Option[CorrelationId], targets: Map[EcuIdentifier, EcuInfoImage])
+
+  implicit val queueResponseDecoder = io.circe.Decoder.instance { cursor =>
+    for {
+      correlationId <- cursor.downField("correlationId").as[Option[CorrelationId]]
+      imagesJson <- cursor.downField("targets").as[Map[EcuIdentifier, Json]]
+      images <- imagesJson.map { case (ecuId, json) =>
+        val image = json.hcursor.downField("image")
+
+        for {
+          filepath <- image.downField("filepath").as[TargetFilename]
+          hashes <- image.downField("fileinfo").downField("hashes").as[Hashes]
+          length <- image.downField("fileinfo").downField("length").as[Long]
+        } yield ecuId -> EcuInfoImage(filepath, length, hashes)
+
+      }.toList.sequence.map(_.toMap)
+    } yield DirectorQueueItem(correlationId, images)
+  }
+
+  implicit val ecuIdentifierKeyEncoder: KeyEncoder[EcuIdentifier] = CirceValidatedGeneric.validatedGenericKeyEncoder
+  implicit val ecuIdentifierKeyDecoder: KeyDecoder[EcuIdentifier] = CirceValidatedGeneric.validatedGenericKeyDecoder
 
   implicit val hashesCodec: Codec[Hashes] = deriveCodec
   implicit val ecuInfoImageCodec: Codec[EcuInfoImage] = deriveCodec
@@ -37,6 +68,8 @@ object DirectorClient {
 
 trait DirectorClient {
   def fetchDeviceEcus(ns: Namespace, deviceId: DeviceId): Future[Seq[EcuInfoResponse]]
+
+  def fetchDeviceQueue(ns: Namespace, deviceId: DeviceId): Future[Seq[DirectorQueueItem]]
 }
 
 class DirectorHttpClient(directorUri: Uri,
@@ -47,12 +80,24 @@ class DirectorHttpClient(directorUri: Uri,
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   import DirectorClient._
 
+  private val _log = LoggerFactory.getLogger(this.getClass)
+
   private def apiUri(path: Path) = directorUri.withPath(Path("/api") / "v1" ++ Slash(path))
 
   override def fetchDeviceEcus(ns: Namespace, deviceId: DeviceId): Future[Seq[EcuInfoResponse]] = {
     val req = HttpRequest(HttpMethods.GET, uri = apiUri(Path(s"admin/devices/${deviceId.uuid.toString}"))).withHeaders(RawHeader("x-ats-namespace", ns.get))
     execHttp[Seq[EcuInfoResponse]](req) {
       case e if e.status == StatusCodes.NotFound =>
+        _log.warn(s"Device $deviceId not found in director (http/404)")
+        FastFuture.successful(Seq.empty)
+    }
+  }
+
+  override def fetchDeviceQueue(ns: Namespace, deviceId: DeviceId): Future[Seq[DirectorQueueItem]] = {
+    val req = HttpRequest(HttpMethods.GET, uri = apiUri(Path(s"assignments/${deviceId.uuid.toString}"))).withHeaders(RawHeader("x-ats-namespace", ns.get))
+    execHttp[Seq[DirectorQueueItem]](req) {
+      case e if e.status == StatusCodes.NotFound =>
+        _log.warn(s"Device assignments for $deviceId not found in director (http/404)")
         FastFuture.successful(Seq.empty)
     }
   }

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
@@ -1,22 +1,23 @@
 package com.advancedtelematic.ota.api_provider.http
 
-import com.advancedtelematic.libats.data.DataType.{HashMethod, Namespace}
-import com.advancedtelematic.libats.data.PaginationResult
+import cats.syntax.option._
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace}
+import com.advancedtelematic.libats.data.{EcuIdentifier, PaginationResult}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import com.advancedtelematic.libtuf.data.ClientDataType.{ClientHashes, ClientTargetItem}
 import com.advancedtelematic.ota.api_provider.client.DirectorClient
-import com.advancedtelematic.ota.api_provider.data.DataType.{ApiDevice, InstalledTarget, ListingDevice, PrimaryEcu}
+import com.advancedtelematic.ota.api_provider.data.DataType.{ApiDevice, ApiDeviceEvent, ApiDeviceEvents, ApiDeviceUpdateEventName, ListingDevice, PrimaryEcu, QueueItem, SoftwareVersion}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.SearchParams
 import com.advancedtelematic.ota.deviceregistry.data.Device
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId
-import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
+import com.advancedtelematic.ota.deviceregistry.db.{DeviceRepository, EventJournal}
 import org.slf4j.LoggerFactory
 import slick.jdbc.MySQLProfile.api._
 
+import scala.async.Async._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
-class ApiProvider(directorClient: DirectorClient)(implicit ec: ExecutionContext, db: Database) {
-
+class ApiProvider(directorClient: DirectorClient, eventJournal: EventJournal)(implicit ec: ExecutionContext, db: Database) {
   private val _log = LoggerFactory.getLogger(this.getClass)
 
   implicit class DeviceToApiTranslation(device: Device) {
@@ -29,8 +30,7 @@ class ApiProvider(directorClient: DirectorClient)(implicit ec: ExecutionContext,
    directorInfo <- directorClient.fetchDeviceEcus(ns, deviceId)
   } yield {
     val primaryEcuInfo = directorInfo.find(_.primary).map { ecuInfo =>
-      val hashes = Map(HashMethod.SHA256 -> ecuInfo.image.hash.sha256)
-      PrimaryEcu(ecuInfo.id, InstalledTarget(ecuInfo.image.filepath, hashes, ecuInfo.image.size))
+      PrimaryEcu(ecuInfo.id, SoftwareVersion(ecuInfo.image.filepath, ecuInfo.image.hash.toClient, ecuInfo.image.size))
     }
 
     if(primaryEcuInfo.isEmpty) {
@@ -45,5 +45,46 @@ class ApiProvider(directorClient: DirectorClient)(implicit ec: ExecutionContext,
     f.map(_.map { device =>
       ListingDevice(device.uuid, device.deviceId)
     })
+  }
+
+  def deviceQueue(ns: Namespace, deviceId: DeviceId): Future[Vector[QueueItem]] = {
+    directorClient.fetchDeviceQueue(ns, deviceId).map { directorQueueItems =>
+      directorQueueItems.map { queueItem =>
+        val updates = queueItem.targets.mapValues { ecuInfoImage =>
+          SoftwareVersion(ecuInfoImage.filepath, ecuInfoImage.hash.toClient, ecuInfoImage.size)
+        }
+
+        queueItem.correlationId match {
+          case Some(cid) =>
+            QueueItem(deviceId, cid, updates).some
+          case None =>
+            _log.warn(s"Received empty correlationId for update for $deviceId, ignoring update")
+            None
+        }
+
+      }.toVector.flatten
+    }
+  }
+
+  def findUpdateEvents(namespace: Namespace, deviceId: DeviceId, correlationId: Option[CorrelationId]): Future[ApiDeviceEvents] = async {
+    val indexedEvents = await(eventJournal.getIndexedEvents(deviceId, correlationId))
+
+    val events = indexedEvents.toVector.flatMap { case (event, indexedEvent) =>
+      val str = indexedEvent.eventType.toString
+        .replace("Ecu", "")
+        .replace("Campaign", "")
+      val eventNameO = Try(ApiDeviceUpdateEventName.withName(str)).toOption
+      val ecuO = event.payload.hcursor.downField("ecu").as[EcuIdentifier].toOption
+
+      eventNameO match {
+        case Some(eventName) =>
+          Option(ApiDeviceEvent(ecuO, indexedEvent.correlationId, eventName, event.receivedAt, event.deviceTime))
+        case _ =>
+          _log.warn(s"Could not extract (ecu, eventName) from event (${event.eventId}, ${event.deviceUuid}")
+          None
+      }
+    }
+
+    ApiDeviceEvents(deviceId, events)
   }
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournal.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournal.scala
@@ -125,7 +125,7 @@ class EventJournal()(implicit db: Database, ec: ExecutionContext) {
   def getIndexedEvents(deviceUuid: DeviceId): Future[Seq[IndexedEvent]] =
     db.run(indexedEvents.filter(_.deviceUuid === deviceUuid).result)
 
-  def getArchivedIndexedEvents(deviceUuid: DeviceId): Future[Seq[IndexedEvent]] =
+  protected [db] def getArchivedIndexedEvents(deviceUuid: DeviceId): Future[Seq[IndexedEvent]] =
     db.run(indexedEventsArchive.filter(_.deviceUuid === deviceUuid).result)
 
   protected [db] def findEventsByCorrelationId(deviceUuid: DeviceId, correlationId: CorrelationId): DBIO[Seq[Event]] = {

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournal.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournal.scala
@@ -131,7 +131,7 @@ class EventJournal()(implicit db: Database, ec: ExecutionContext) {
   protected [db] def findEventsByCorrelationId(deviceUuid: DeviceId, correlationId: CorrelationId): DBIO[Seq[Event]] = {
     EventJournal.events
       .filter(_.deviceUuid === deviceUuid)
-      .join(EventJournal.indexedEvents)
+      .join(EventJournal.indexedEvents.filter(_.correlationId === correlationId))
       .on { case (ej, ie) => ej.deviceUuid === ie.deviceUuid && ej.eventId === ie.eventId }
       .map(_._1)
       .result

--- a/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
@@ -1,25 +1,36 @@
 package com.advancedtelematic.ota.api_provider.http
 
-import akka.http.scaladsl.model.Uri.Path
+import java.time.Instant
+import java.util.UUID
+
+import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import com.advancedtelematic.libats.data.{EcuIdentifier, PaginationResult}
 import com.advancedtelematic.ota.deviceregistry.{DeviceRequests, ResourceSpec}
 import com.advancedtelematic.ota.deviceregistry.data.DeviceStatus
 import org.scalatest.FunSuite
-import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import com.advancedtelematic.ota.deviceregistry.data.GeneratorOps._
 import cats.syntax.show._
 import cats.syntax.either._
-import com.advancedtelematic.libats.data.DataType.ValidChecksum
+import com.advancedtelematic.libats.data.DataType.{CampaignId, ValidChecksum}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId._
 import com.advancedtelematic.libtuf.data.TufDataType.{ValidHardwareIdentifier, ValidTargetFilename}
-import com.advancedtelematic.ota.api_provider.client.DirectorClient.{EcuInfoImage, Hashes}
+import com.advancedtelematic.ota.api_provider.client.DirectorClient.{DirectorQueueItem, EcuInfoImage, Hashes}
 import com.advancedtelematic.libats.data.RefinedUtils.RefineTry
+import cats.syntax.option._
+import com.advancedtelematic.libats.messaging_datatype.DataType.{Event, EventType}
+import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceEventMessage
+import com.advancedtelematic.ota.deviceregistry.daemon.DeviceEventListener
+import io.circe.syntax._
+import org.scalatest.OptionValues._
 
-class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually with DeviceRequests {
+class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually with DeviceRequests with ScalaFutures {
 
   import com.advancedtelematic.ota.api_provider.data.DataType._
+
+  private val deviceEventListener = new DeviceEventListener()
 
   private def apiProviderUri(pathSuffixes: String*): Uri = {
     val BasePath = Path("/api-provider") / "api" / "v1alpha"
@@ -114,6 +125,138 @@ class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually 
       apiDevice.status shouldBe DeviceStatus.NotSeen
 
       apiDevice.primaryEcu shouldBe empty
+    }
+  }
+
+
+  test("returns an empty device queue") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+
+    Get(apiProviderUri("devices", deviceId.show, "queue")) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val queue = responseAs[List[Unit]]
+      queue shouldBe empty
+    }
+  }
+
+  test("returns a non empty device queue") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+
+    val ecuId = EcuIdentifier("somefakeid").valueOr(throw _)
+    val correlationId = CampaignId(UUID.randomUUID())
+    val targetFilename = "some-hash".refineTry[ValidTargetFilename].get
+    val hash = "848cba347e8a37330b97835936dd4f846291739d0d5efa9eb10c75e4c15ba87a".refineTry[ValidChecksum].get
+    val image = EcuInfoImage(targetFilename, 2222, Hashes(hash))
+
+    directorClient.addQueueItem(deviceId, DirectorQueueItem(correlationId.some, Map(ecuId -> image)))
+
+    Get(apiProviderUri("devices", deviceId.show, "queue")) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val queue = responseAs[List[QueueItem]]
+      queue should have size(1)
+
+      queue.head.updateId shouldBe correlationId
+      queue.head.deviceUuid shouldBe deviceId
+      queue.head.ecus should contain key(ecuId)
+      val (_, softwareVersion) = queue.head.ecus.head
+
+      softwareVersion.filename shouldBe targetFilename
+    }
+  }
+
+  test("returns an empty queue when correlation id in director is empty") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+
+    directorClient.addQueueItem(deviceId, DirectorQueueItem(correlationId = None, Map.empty))
+
+    Get(apiProviderUri("devices", deviceId.show, "queue")) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val queue = responseAs[List[QueueItem]]
+      queue shouldBe empty
+    }
+  }
+
+  test("events includes events for a device") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+    val ecuId = EcuIdentifier("somefakeid").valueOr(throw _)
+    val campaignIdUuid = UUID.randomUUID()
+    val campaignId = CampaignId(campaignIdUuid)
+    val now = Instant.now()
+
+    val payload = Map(
+      "ecu" -> ecuId.asJson,
+      "correlationId" -> campaignId.toString().asJson,
+      "campaignId" -> campaignIdUuid.toString.asJson
+    ).asJson
+
+    val event01 = Event(deviceId, UUID.randomUUID().toString, EventType("campaign_accepted", 0), now, now, payload)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event01)).futureValue
+
+    val event02 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationStarted", 0), now.plusMillis(1), now.plusMillis(1), payload)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event02)).futureValue
+
+    val event03 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationCompleted", 0), now.plusMillis(2), now.plusMillis(2), payload)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event03)).futureValue
+
+    Get(apiProviderUri("devices", deviceId.show, "events")) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val updateStatus = responseAs[ApiDeviceEvents]
+
+      updateStatus.deviceUuid shouldBe deviceId
+
+      val events = updateStatus.events
+
+      events should have size(3)
+
+      println(events)
+
+      events.headOption.value.updateId.value shouldBe campaignId
+      events.headOption.value.ecuId.value shouldBe ecuId
+      events.map(_.name) shouldBe Vector(ApiDeviceUpdateEventName.InstallationCompleted, ApiDeviceUpdateEventName.InstallationStarted, ApiDeviceUpdateEventName.Accepted)
+    }
+  }
+
+  test("returns events filtered by updateId") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+    val ecuId = EcuIdentifier("somefakeid").valueOr(throw _)
+        val now = Instant.now()
+
+    val campaignId01 = CampaignId(UUID.randomUUID())
+    val campaignId02 = CampaignId(UUID.randomUUID())
+
+    val payload01 = Map(
+      "ecu" -> ecuId.asJson,
+      "correlationId" -> campaignId01.toString().asJson
+    ).asJson
+
+    val payload02 = Map(
+      "ecu" -> ecuId.asJson,
+      "correlationId" -> campaignId02.toString().asJson
+    ).asJson
+
+    val event01 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationStarted", 0), now, now, payload01)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event01)).futureValue
+
+    val event02 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationCompleted", 0), now, now, payload02)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event02)).futureValue
+
+    Get(apiProviderUri("devices", deviceId.show, "events").withQuery(Uri.Query("updateId" -> campaignId01.toString()))) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val updateStatus = responseAs[ApiDeviceEvents]
+
+      updateStatus.deviceUuid shouldBe deviceId
+
+      val events = updateStatus.events
+
+      events should have size(1)
+
+      events.headOption.value.updateId.value shouldBe campaignId01
+      events.map(_.name).headOption.value shouldBe ApiDeviceUpdateEventName.InstallationStarted
     }
   }
 }

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournalSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournalSpec.scala
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package com.advancedtelematic.ota.deviceregistry
+package com.advancedtelematic.ota.deviceregistry.db
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -19,7 +19,8 @@ import com.advancedtelematic.libats.data.DataType.{CampaignId, CorrelationId, Mu
 import com.advancedtelematic.libats.messaging_datatype.DataType.{Event, EventType}
 import com.advancedtelematic.libats.messaging_datatype.MessageCodecs._
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceEventMessage
-import com.advancedtelematic.ota.deviceregistry.EventJournalSpec.EventPayload
+import com.advancedtelematic.ota.deviceregistry.ResourcePropSpec
+import com.advancedtelematic.ota.deviceregistry.db.EventJournalSpec.EventPayload
 import com.advancedtelematic.ota.deviceregistry.daemon.{DeleteDeviceHandler, DeviceEventListener}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
 import com.advancedtelematic.ota.deviceregistry.db.EventJournal
@@ -30,6 +31,7 @@ import io.circe.{Decoder, Json}
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.SpanSugar._
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 
 object EventJournalSpec {
   private[EventJournalSpec] final case class EventPayload(id: UUID,
@@ -52,7 +54,6 @@ object EventJournalSpec {
 
 class EventJournalSpec extends ResourcePropSpec with ScalaFutures with Eventually with ArbitraryInstances {
   import com.advancedtelematic.ota.deviceregistry.data.GeneratorOps._
-  import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   import io.circe.syntax._
 
   private[this] val InstantGen: Gen[Instant] = Gen

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournalSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournalSpec.scala
@@ -23,7 +23,6 @@ import com.advancedtelematic.ota.deviceregistry.ResourcePropSpec
 import com.advancedtelematic.ota.deviceregistry.db.EventJournalSpec.EventPayload
 import com.advancedtelematic.ota.deviceregistry.daemon.{DeleteDeviceHandler, DeviceEventListener}
 import com.advancedtelematic.ota.deviceregistry.data.DataType.DeviceT
-import com.advancedtelematic.ota.deviceregistry.db.EventJournal
 import com.advancedtelematic.ota.deviceregistry.messages.DeleteDeviceRequest
 import io.circe.generic.semiauto._
 import io.circe.testing.ArbitraryInstances
@@ -165,7 +164,7 @@ class EventJournalSpec extends ResourcePropSpec with ScalaFutures with Eventuall
     new DeleteDeviceHandler().apply(new DeleteDeviceRequest(defaultNs, uuid))
 
     eventually(timeout(5.seconds), interval(100.millis)) {
-      journal.getIndexedEvents(uuid).futureValue shouldBe Nil
+      journal.getIndexedEvents(uuid, correlationId = None).futureValue shouldBe empty
       journal.getArchivedIndexedEvents(uuid).futureValue.map(_.eventID) shouldBe Seq(event.eventId)
     }
   }


### PR DESCRIPTION
Implement device queue and device events endpoints for public api
    
    `devices/:device-uuid/queue` returns the queue for a device
    
    `devices/:device-uuid/events` returns events received from a device


Fixed a bug when getting events by correlation id

Correct a few api definition typos