### PR TITLE
Sort events by deviceTime, createdAt

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournal.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/EventJournal.scala
@@ -62,6 +62,7 @@ object EventJournal {
     def eventId = column[String]("event_id")
     def eventType = column[IndexedEventType]("event_type")
     def correlationId = column[Option[CorrelationId]]("correlation_id")
+    def createdAt = column[Instant]("created_at")
 
     def pk = primaryKey("indexed_event_pk", (deviceUuid, eventId))
 
@@ -128,7 +129,7 @@ class EventJournal()(implicit db: Database, ec: ExecutionContext) {
       .filter(_.deviceUuid === deviceUuid)
       .join(EventJournal.indexedEvents.maybeFilter(_.correlationId === correlationId))
       .on { case (ej, ie) => ej.deviceUuid === ie.deviceUuid && ej.eventId === ie.eventId }
-      .sortBy(_._1.deviceTime.desc)
+      .sortBy { case (ej, ie) => ej.deviceTime.desc -> ie.createdAt.desc }
       .result
   }
 


### PR DESCRIPTION
Since we receive events using http, and then publish them into the bus
for async processing, using json, we loose precision due to the usage
of our custom json codec [1].

Changing that codec would probably break a lot of tests, so we
discriminate equal receivedAt times using createdAt

[1]: https://github.com/advancedtelematic/libats/blob/269e84d49db434744b4b47d861fa6491210c0286/libats/src/main/scala/com/advancedtelematic/libats/codecs/CirceCodecs.scala#L27

Signed-off-by: Simão Mata <simao.mata@here.com>