### PR TITLE
Add connection akka metrics

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -10,6 +10,20 @@ instanceId=${?MESOS_TASK_ID}
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "INFO"
+
+  http {
+    server {
+      max-connections = 2048
+      max-connections = ${?AKKA_HTTP_MAX_CONNECTIONS}
+    }
+
+    host-connection-pool {
+      max-connections = 2048
+      max-connections = ${?AKKA_HTTP_CLIENT_MAX_CONNECTIONS}
+      max-open-requests = 4096
+      max-open-requests = ${?AKKA_HTTP_CLIENT_MAX_OPEN_REQUESTS}
+    }
+  }
 }
 
 auth = {

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/Boot.scala
@@ -22,7 +22,7 @@ import com.advancedtelematic.libats.messaging._
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.slick.db.{CheckMigrations, DatabaseConfig}
 import com.advancedtelematic.libats.slick.monitoring.{DatabaseMetrics, DbHealthResource}
-import com.advancedtelematic.metrics.AkkaHttpRequestMetrics
+import com.advancedtelematic.metrics.{AkkaHttpConnectionMetrics, AkkaHttpRequestMetrics}
 import com.advancedtelematic.metrics.prometheus.PrometheusMetricsSupport
 import com.advancedtelematic.ota.api_provider.client.DirectorHttpClient
 import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository
@@ -40,6 +40,7 @@ trait Settings {
 
 object Boot extends BootApp
   with AkkaHttpRequestMetrics
+  with AkkaHttpConnectionMetrics
   with CheckMigrations
   with DatabaseConfig
   with DatabaseMetrics
@@ -81,7 +82,7 @@ object Boot extends BootApp
   val parserSettings = ParserSettings(system).withCustomMediaTypes(`application/toml`.mediaType)
   val serverSettings = ServerSettings(system).withParserSettings(parserSettings)
 
-  Http().bindAndHandle(routes, host, port, settings = serverSettings)
+  Http().bindAndHandle(withConnectionMetrics(routes, metricRegistry), host, port, settings = serverSettings)
 
   log.info(s"device registry started at http://$host:$port/")
 


### PR DESCRIPTION
Add application.conf parameters to configure akka connection pool

The director performance saga continues. Now device gw doesn't forward requests to director because it is stuck on device registry, so we need to increase capacity there as well:

```
{"logger":"c.a.a.g.a.DeviceRegistryAuthFilter","at":"2019-12-04T14:51:07.992Z","msg":"Request to device registry failed.","throwable":"com.twitter.finagle.Failure: connection timed out: ota-director/100.69.123.192:80 at remote address: ota-director/100.69.123.192:80. Remote Info: Not Available\nCaused by: com.twitter.finagle.ConnectionFailedException: connection timed out: ota-director/100.69.123.192:80 at remote address: ota-director/100.69.123.192:80. Remote Info: Not Available\n\tat com.twitter.finagle.netty4.ConnectionBuilder$$anon$1.operationComplete(ConnectionBuilder.scala:100)\n\tat com.twitter.finagle.netty4.ConnectionBuilder$$anon$1.operationComplete(ConnectionBuilder.scala:79)\n\tat io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:502)\n\tat io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:495)\n\tat io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:474)\n\tat io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:415)\n\tat io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:540)\n\tat io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:533)\n\tat io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:114)\n\tat io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe$2.run(AbstractEpollChannel.java:575)\n\tat io.netty.util.concurrent.PromiseTask$RunnableAdapter.call(PromiseTask.java:38)\n\tat io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:127)\n\tat io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:405)\n\tat io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:338)\n\tat io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:906)\n\tat io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat com.twitter.finagle.util.BlockingTimeTrackingThreadFactory$$anon$1.run(BlockingTimeTrackingThreadFactory.scala:23)\n\tat io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)\n\tat java.lang.Thread.run(Thread.java:748)\nCaused by: io.netty.channel.ConnectTimeoutException: connection timed out: ota-director/100.69.123.192:80\n\tat io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe$2.run(AbstractEpollChannel.java:573)\n\t... 12 common frames omitted\n","level":"ERROR"}
```

Signed-off-by: Simão Mata <simao.mata@here.com>