### PR TITLE
Use event names from IndexedEventType for public API

### DIFF
--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -213,16 +213,16 @@ components:
                 type: string
                 enum:
                   - DownloadComplete
-                  - DownloadStarted
-                  - DownloadCompleted
-                  - InstallationStarted
-                  - InstallationApplied
-                  - InstallationCompleted
+                  - EcuDownloadStarted
+                  - EcuDownloadCompleted
+                  - EcuInstallationStarted
+                  - EcuInstallationApplied
+                  - EcuInstallationCompleted
                   - DevicePaused
                   - DeviceResumed
-                  - Accepted
-                  - Declined
-                  - Postponed
+                  - CampaignAccepted
+                  - CampaignDeclined
+                  - CampaignPostponed
                   - InstallationComplete
               receivedTime:
                 type: string

--- a/src/main/scala/com/advancedtelematic/ota/api_provider/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/data/DataType.scala
@@ -16,8 +16,9 @@ import com.advancedtelematic.ota.deviceregistry.data.Codecs._
 import com.advancedtelematic.ota.deviceregistry.data.Device.DeviceOemId._
 import com.advancedtelematic.libats.codecs.JsonDropNullValues._
 import com.advancedtelematic.libats.data.DataType.CorrelationId
-import com.advancedtelematic.ota.api_provider.data.DataType.ApiDeviceUpdateEventName.ApiDeviceUpdateEventName
 import com.advancedtelematic.ota.api_provider.client.DirectorClient._
+import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType
+import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType.IndexedEventType
 
 
 object DataType {
@@ -40,22 +41,7 @@ object DataType {
 
   type ApiUpdateId = CorrelationId
 
-  object ApiDeviceUpdateEventName extends Enumeration {
-    type ApiDeviceUpdateEventName = Value
-
-    val DownloadComplete,
-    DownloadStarted,
-    DownloadCompleted,
-    InstallationStarted,
-    InstallationApplied,
-    InstallationCompleted,
-    DevicePaused,
-    DeviceResumed,
-    Accepted,
-    Declined,
-    Postponed,
-    InstallationComplete = Value
-  }
+  type ApiDeviceUpdateEventName = IndexedEventType
 
   case class ApiDeviceEvent(ecuId: Option[EcuIdentifier], updateId: Option[ApiUpdateId], name: ApiDeviceUpdateEventName,
                             receivedTime: Instant, deviceTime: Instant)
@@ -68,7 +54,7 @@ object DataType {
 
   implicit val queueItemCodec = deriveCodec[QueueItem]
 
-  implicit val apiDeviceUpdateEventNameCodec = io.circe.Codec.codecForEnumeration(ApiDeviceUpdateEventName)
+  implicit val apiDeviceUpdateEventNameCodec = io.circe.Codec.codecForEnumeration(IndexedEventType)
 
   implicit val apiDeviceUpdateCodec = deriveCodec[ApiDeviceEvent]
 

--- a/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
@@ -3,7 +3,7 @@ package com.advancedtelematic.ota.api_provider.http
 import java.time.Instant
 import java.util.UUID
 
-import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import com.advancedtelematic.libats.data.{EcuIdentifier, PaginationResult}
 import com.advancedtelematic.ota.deviceregistry.{DeviceRequests, ResourceSpec}
@@ -23,6 +23,7 @@ import cats.syntax.option._
 import com.advancedtelematic.libats.messaging_datatype.DataType.{Event, EventType}
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceEventMessage
 import com.advancedtelematic.ota.deviceregistry.daemon.DeviceEventListener
+import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType
 import io.circe.syntax._
 import org.scalatest.OptionValues._
 
@@ -216,7 +217,7 @@ class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually 
 
       events.headOption.value.updateId.value shouldBe campaignId
       events.headOption.value.ecuId.value shouldBe ecuId
-      events.map(_.name) shouldBe Vector(ApiDeviceUpdateEventName.InstallationCompleted, ApiDeviceUpdateEventName.InstallationStarted, ApiDeviceUpdateEventName.Accepted)
+      events.map(_.name) shouldBe Vector(IndexedEventType.EcuInstallationCompleted, IndexedEventType.EcuInstallationStarted, IndexedEventType.CampaignAccepted)
     }
   }
 
@@ -256,7 +257,7 @@ class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually 
       events should have size(1)
 
       events.headOption.value.updateId.value shouldBe campaignId01
-      events.map(_.name).headOption.value shouldBe ApiDeviceUpdateEventName.InstallationStarted
+      events.map(_.name).headOption.value shouldBe IndexedEventType.EcuInstallationStarted
     }
   }
 }


### PR DESCRIPTION
Initially I thought it would be a good idea to simplify these events
and remove `Ecu` and `Campaign` from them, but this just confuses
users further. So here I am removing that translation and using
IndexedEventType directly.

Signed-off-by: Simão Mata <simao.mata@here.com>