### PR TITLE
Do not return duplicate queue items

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
+++ b/src/main/scala/com/advancedtelematic/ota/api_provider/http/ApiProvider.scala
@@ -15,7 +15,7 @@ import slick.jdbc.MySQLProfile.api._
 
 import scala.async.Async._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+
 
 class ApiProvider(directorClient: DirectorClient, eventJournal: EventJournal)(implicit ec: ExecutionContext, db: Database) {
   private val _log = LoggerFactory.getLogger(this.getClass)
@@ -62,7 +62,7 @@ class ApiProvider(directorClient: DirectorClient, eventJournal: EventJournal)(im
             None
         }
 
-      }.toVector.flatten
+      }.toVector.flatten.distinct
     }
   }
 


### PR DESCRIPTION
One of the many bugs of director is that it sometimes returns
duplicate queue items, even if they refer to the same update, on the
same ecu. This change makes sure we only return one of those updates