### PR TITLE
Returns processed/indexed events

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceRegistryRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceRegistryRoutes.scala
@@ -25,15 +25,24 @@ class DeviceRegistryRoutes(
     extends Directives {
 
   val route: Route =
-    pathPrefix("api" / "v1") {
-      handleRejections(rejectionHandler) {
-        ErrorHandler.handleErrors {
-          new DevicesResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
-          new SystemInfoResource(messageBus, namespaceExtractor, deviceNamespaceAuthorizer).route ~
-          new PublicCredentialsResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
-          new GroupsResource(namespaceExtractor, deviceNamespaceAuthorizer).route
+    pathPrefix("api") {
+      pathPrefix("v1") {
+        handleRejections(rejectionHandler) {
+          ErrorHandler.handleErrors {
+            new DevicesResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
+            new SystemInfoResource(messageBus, namespaceExtractor, deviceNamespaceAuthorizer).route ~
+            new PublicCredentialsResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
+            new GroupsResource(namespaceExtractor, deviceNamespaceAuthorizer).route
+          }
+        }
+      } ~
+      pathPrefix("v2") {
+        handleRejections(rejectionHandler) {
+          ErrorHandler.handleErrors {
+            new DeviceResource2(namespaceExtractor, deviceNamespaceAuthorizer).route
+          }
+        }
       }
-    }
-  } ~
-      new ApiProviderRoutes(namespaceExtractor, deviceNamespaceAuthorizer, directorClient).route
+    } ~
+    new ApiProviderRoutes(namespaceExtractor, deviceNamespaceAuthorizer, directorClient).route
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceResource2.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceResource2.scala
@@ -1,0 +1,69 @@
+package com.advancedtelematic.ota.deviceregistry
+
+import java.time.Instant
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive1, Route}
+import com.advancedtelematic.libats.auth.AuthedNamespaceScope
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, Namespace}
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.DevicesResource.correlationIdUnmarshaller
+import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType.IndexedEventType
+import com.advancedtelematic.ota.deviceregistry.db.EventJournal
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import slick.jdbc.MySQLProfile.api._
+import com.advancedtelematic.libats.codecs.CirceCodecs._
+import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType
+import com.advancedtelematic.ota.deviceregistry.DeviceResource2.{ApiDeviceEvent, ApiDeviceEvents}
+
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future}
+
+object DeviceResource2 {
+  import io.circe.generic.semiauto._
+
+  type ApiUpdateId = CorrelationId
+
+  type ApiDeviceUpdateEventName = IndexedEventType
+
+  case class ApiDeviceEvent(ecuId: Option[EcuIdentifier], updateId: Option[ApiUpdateId], name: ApiDeviceUpdateEventName,
+                            receivedTime: Instant, deviceTime: Instant)
+
+  case class ApiDeviceEvents(deviceUuid: DeviceId, events: Vector[ApiDeviceEvent])
+
+
+  implicit val apiDeviceUpdateEventNameCodec = io.circe.Codec.codecForEnumeration(IndexedEventType)
+
+  implicit val apiDeviceUpdateCodec = deriveCodec[ApiDeviceEvent]
+
+  implicit val apiUpdateStatusCodec = deriveCodec[ApiDeviceEvents]
+}
+
+class DeviceResource2(namespaceExtractor: Directive1[AuthedNamespaceScope], deviceNamespaceAuthorizer: Directive1[DeviceId])
+                     (implicit db: Database, ec: ExecutionContext) {
+
+  val eventJournal = new EventJournal()
+
+  def findUpdateEvents(namespace: Namespace, deviceId: DeviceId, correlationId: Option[CorrelationId]): Future[ApiDeviceEvents] = async {
+    val indexedEvents = await(eventJournal.getIndexedEvents(deviceId, correlationId))
+
+    val events = indexedEvents.toVector.map { case (event, indexedEvent) =>
+      val ecuO = event.payload.hcursor.downField("ecu").as[EcuIdentifier].toOption
+      ApiDeviceEvent(ecuO, indexedEvent.correlationId, indexedEvent.eventType, event.receivedAt, event.deviceTime)
+    }
+
+    ApiDeviceEvents(deviceId, events)
+  }
+
+  def route: Route = namespaceExtractor { ns =>
+    pathPrefix("devices") {
+      deviceNamespaceAuthorizer { uuid =>
+        (get & path("events") & parameter('updateId.as[CorrelationId].?)) { correlationId =>
+          val f = findUpdateEvents(ns.namespace, uuid, correlationId)
+          complete(f)
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/api_provider/http/DeviceInfoResourceSpec.scala
@@ -39,13 +39,6 @@ class DeviceInfoResourceSpec extends FunSuite with ResourceSpec with Eventually 
     Uri.Empty.withPath(pathSuffixes.foldLeft(BasePath)(_ / _))
   }
 
-  test("sets different provider version header") {
-    Get(apiProviderUri("devices"))  ~> route ~> check {
-      status shouldBe StatusCodes.OK
-      response.headers.find(_.is("x-here-ota-api-provider-version")).map(_.value()) should contain("api-provider@device-registry")
-    }
-  }
-
   test("list devices, paginated") {
     val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
     createDeviceOk(device)

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceRequests.scala
@@ -42,6 +42,11 @@ object Resource {
     val BasePath = Path("/api") / "v1"
     Uri.Empty.withPath(pathSuffixes.foldLeft(BasePath)(_ / _))
   }
+
+  def uriV2(pathSuffixes: String*): Uri = {
+    val BasePath = Path("/api") / "v2"
+    Uri.Empty.withPath(pathSuffixes.foldLeft(BasePath)(_ / _))
+  }
 }
 
 /**
@@ -188,6 +193,11 @@ trait DeviceRequests { self: ResourceSpec =>
   def getEvents(deviceUuid: DeviceId, correlationId: Option[CorrelationId] = None): HttpRequest = {
     val query = Query(correlationId.map("correlationId" -> _.toString).toMap)
     Get(Resource.uri(api, deviceUuid.show, "events").withQuery(query))
+  }
+
+  def getEventsV2(deviceUuid: DeviceId, updateId: Option[CorrelationId] = None): HttpRequest = {
+    val query = Query(updateId.map("updateId" -> _.toString).toMap)
+    Get(Resource.uriV2(api, deviceUuid.show, "events").withQuery(query))
   }
 
   def getGroupsOfDevice(deviceUuid: DeviceId): HttpRequest = Get(Resource.uri(api, deviceUuid.show, "groups"))

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResource2Spec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/DeviceResource2Spec.scala
@@ -1,0 +1,108 @@
+package com.advancedtelematic.ota.deviceregistry
+
+import java.time.Instant
+import java.util.UUID
+
+import akka.http.scaladsl.model.StatusCodes
+import com.advancedtelematic.libats.messaging_datatype.DataType.{Event, EventType}
+import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceEventMessage
+import com.advancedtelematic.ota.deviceregistry.daemon.DeviceEventListener
+import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import com.advancedtelematic.libats.codecs.CirceCodecs._
+import com.advancedtelematic.libats.data.DataType.CampaignId
+import com.advancedtelematic.libats.data.EcuIdentifier
+import com.advancedtelematic.ota.deviceregistry.DeviceResource2.ApiDeviceEvents
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.testing.ArbitraryInstances
+import org.scalatest.FunSuite
+import cats.syntax.either._
+import org.scalatest.OptionValues._
+
+
+class DeviceResource2Spec extends FunSuite with ResourceSpec with Eventually with ScalaFutures with ArbitraryInstances {
+  import com.advancedtelematic.ota.deviceregistry.data.GeneratorOps._
+  import io.circe.syntax._
+
+  private val deviceEventListener = new DeviceEventListener()
+
+  test("events includes events for a device") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+    val ecuId = EcuIdentifier("somefakeid").valueOr(throw _)
+    val campaignIdUuid = UUID.randomUUID()
+    val campaignId = CampaignId(campaignIdUuid)
+    val now = Instant.now()
+
+    val payload = Map(
+      "ecu" -> ecuId.asJson,
+      "correlationId" -> campaignId.toString().asJson,
+      "campaignId" -> campaignIdUuid.toString.asJson
+    ).asJson
+
+    val event01 = Event(deviceId, UUID.randomUUID().toString, EventType("campaign_accepted", 0), now, now, payload)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event01)).futureValue
+
+    val event02 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationStarted", 0), now.plusMillis(1), now.plusMillis(1), payload)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event02)).futureValue
+
+    val event03 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationCompleted", 0), now.plusMillis(2), now.plusMillis(2), payload)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event03)).futureValue
+
+    getEventsV2(deviceId) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val updateStatus = responseAs[ApiDeviceEvents]
+
+      updateStatus.deviceUuid shouldBe deviceId
+
+      val events = updateStatus.events
+
+      events should have size(3)
+
+      events.headOption.value.updateId.value shouldBe campaignId
+      events.headOption.value.ecuId.value shouldBe ecuId
+      events.map(_.name) shouldBe Vector(IndexedEventType.EcuInstallationCompleted, IndexedEventType.EcuInstallationStarted, IndexedEventType.CampaignAccepted)
+    }
+  }
+
+  test("returns events filtered by updateId") {
+    val device = genDeviceT.retryUntil(_.uuid.isDefined).generate
+    val deviceId = createDeviceOk(device)
+    val ecuId = EcuIdentifier("somefakeid").valueOr(throw _)
+    val now = Instant.now()
+
+    val campaignId01 = CampaignId(UUID.randomUUID())
+    val campaignId02 = CampaignId(UUID.randomUUID())
+
+    val payload01 = Map(
+      "ecu" -> ecuId.asJson,
+      "correlationId" -> campaignId01.toString().asJson
+    ).asJson
+
+    val payload02 = Map(
+      "ecu" -> ecuId.asJson,
+      "correlationId" -> campaignId02.toString().asJson
+    ).asJson
+
+    val event01 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationStarted", 0), now, now, payload01)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event01)).futureValue
+
+    val event02 = Event(deviceId, UUID.randomUUID().toString, EventType("EcuInstallationCompleted", 0), now, now, payload02)
+    deviceEventListener.apply(DeviceEventMessage(defaultNs, event02)).futureValue
+
+    getEventsV2(deviceId, Some(campaignId01)) ~> route ~> check {
+      status shouldBe StatusCodes.OK
+      val updateStatus = responseAs[ApiDeviceEvents]
+
+      updateStatus.deviceUuid shouldBe deviceId
+
+      val events = updateStatus.events
+
+      events should have size(1)
+
+      events.headOption.value.updateId.value shouldBe campaignId01
+      events.map(_.name).headOption.value shouldBe IndexedEventType.EcuInstallationStarted
+    }
+  }
+
+}


### PR DESCRIPTION
After looking into this OTA-4163 needs some work outside of the scope of OTA-4320, so this is just part of OTA-4320.

Copied over the code and test from API provider. Created a v2 of the `devices/$deviceId/events` endpoint. The api provider code will be removed later once OTA-4320 is done.

Signed-off-by: Jochen Schneider <j.schneider@here.com>