### PR TITLE
[OTA-3654] Migrate blacklisting feature from ota-core

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -54,6 +54,14 @@ server {
   port = ${?BIND_PORT}
 }
 
+sota_core = {
+  host = "localhost"
+  host = ${?SOTA_CORE_HOST}
+  port = 8080
+  port = ${?SOTA_CORE_PORT}
+  uri = "http://"${sota_core.host}":"${sota_core.port}
+}
+
 main {
   defaultNs = "default"
   defaultNs = ${?DEFAULT_NAMESPACE}

--- a/src/main/resources/db/migration/V31__add_package_list_items.sql
+++ b/src/main/resources/db/migration/V31__add_package_list_items.sql
@@ -1,0 +1,10 @@
+CREATE TABLE PackageListItem (
+  namespace VARCHAR(255) NOT NULL,
+  package_name VARCHAR(200) NOT NULL,
+  package_version VARCHAR(200) NOT NULL,
+  `comment` TEXT NOT NULL,
+  created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+
+  PRIMARY KEY (namespace, package_name, package_version)
+);

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceRegistryRoutes.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/DeviceRegistryRoutes.scala
@@ -29,6 +29,7 @@ class DeviceRegistryRoutes(
             new DevicesResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
             new SystemInfoResource(messageBus, namespaceExtractor, deviceNamespaceAuthorizer).route ~
             new PublicCredentialsResource(namespaceExtractor, messageBus, deviceNamespaceAuthorizer).route ~
+            new PackageListsResource(namespaceExtractor, deviceNamespaceAuthorizer).route ~
             new GroupsResource(namespaceExtractor, deviceNamespaceAuthorizer).route
           }
         }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/PackageListsResource.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/PackageListsResource.scala
@@ -1,0 +1,83 @@
+package com.advancedtelematic.ota.deviceregistry
+
+import akka.http.scaladsl.model.StatusCodes.{Created, NoContent}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import com.advancedtelematic.libats.auth.{AuthedNamespaceScope, Scopes}
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.data.Codecs._
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{PackageListItem, PackageListItemCount}
+import com.advancedtelematic.ota.deviceregistry.data.PackageId
+import com.advancedtelematic.ota.deviceregistry.db.PackageListItemRepository
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.generic.auto._
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * This "package lists" feature has been migrated from the deprecated
+  * ota-core service, where it used to be a "blacklisting" feature. It's
+  * been migrated here to terminate ota-core.
+  *
+  * The feature was not actually blacklisting anything. Instead, it was
+  * used to count the number of devices that have a particular package
+  * installed. This are the installed packages reported by aktualizr,
+  * e.g. 'nano' for a linux distribution, not to be confused with the
+  * software images we can install through our system. The count of
+  * the packages is displayed in the "Impact" tab of the web app.
+  *
+  * While moving it here, we've chosen to rename this to "package lists"
+  * instead of "blacklisted packages", for lack of a better description
+  * of what the feature was being used for.
+  */
+class PackageListsResource(namespaceExtractor: Directive1[AuthedNamespaceScope],
+                           deviceNamespaceAuthorizer: Directive1[DeviceId],
+                          )(implicit db: Database, ec: ExecutionContext) {
+
+  private val extractPackageId: Directive1[PackageId] =
+    pathPrefix(Segment / Segment).as(PackageId.apply)
+
+  private def getPackageListItem(ns: Namespace, packageId: PackageId): Future[PackageListItem] =
+    db.run(PackageListItemRepository.fetchPackageListItem(ns, packageId))
+
+  private def getPackageListItemCounts(ns: Namespace): Future[Seq[PackageListItemCount]] =
+    db.run(PackageListItemRepository.fetchPackageListItemCounts(ns))
+
+  private def createPackageListItem(packageListItem: PackageListItem): Future[Unit] =
+    db.run(PackageListItemRepository.create(packageListItem).map(_ => ()))
+
+  private def updatePackageListItem(patchedPackageListItem: PackageListItem): Future[Unit] =
+    db.run(PackageListItemRepository.update(patchedPackageListItem).map(_ => ()))
+
+  private def deletePackageListItem(ns: Namespace, packageId: PackageId): Future[Unit] =
+    db.run(PackageListItemRepository.remove(ns, packageId).map(_ => ()))
+
+  val route: Route = namespaceExtractor { namespace =>
+    val scope = Scopes.devices(namespace)
+    val ns = namespace.namespace
+    pathPrefix("package_lists") {
+      pathEnd {
+        scope.get {
+          complete(getPackageListItemCounts(ns))
+        } ~
+        (scope.post & entity(as[Namespace => PackageListItem])) { fn =>
+          complete(Created -> createPackageListItem(fn(ns)))
+        } ~
+        // This would better be as a PATCH /package_lists/package-name/package-version, but the UI is already sending this request.
+        (scope.put & entity(as[Namespace => PackageListItem])) { fn =>
+          complete(NoContent -> updatePackageListItem(fn(ns)))
+        }
+      } ~
+      extractPackageId { packageId =>
+        scope.get {
+          complete(getPackageListItem(ns, packageId))
+        } ~
+        scope.delete {
+          complete(NoContent -> deletePackageListItem(ns, packageId))
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/client/SotaCoreClient.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/client/SotaCoreClient.scala
@@ -1,0 +1,36 @@
+package com.advancedtelematic.ota.deviceregistry.client
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model._
+import akka.stream.Materializer
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.http.HttpOps.HttpRequestOps
+import com.advancedtelematic.libats.http.ServiceHttpClient
+import com.advancedtelematic.ota.deviceregistry.data.DataType.PackageListItem
+import com.advancedtelematic.ota.deviceregistry.data.PackageId
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.Decoder
+
+import scala.concurrent.{ExecutionContext, Future}
+
+final case class SotaCoreBlacklistedPackage(packageId: PackageId, comment: String)
+
+trait SotaCoreClient {
+  def getBlacklistedPackages(ns: Namespace): Future[Seq[PackageListItem]]
+}
+
+class SotaCoreHttpClient(uri: Uri, httpClient: HttpRequest => Future[HttpResponse])
+                        (implicit ec: ExecutionContext, system: ActorSystem, mat: Materializer) extends ServiceHttpClient(httpClient) with SotaCoreClient {
+
+  implicit val deviceUpdateReportDecoder: Decoder[SotaCoreBlacklistedPackage] = io.circe.generic.semiauto.deriveDecoder
+
+  private def sotaPakageToPackage(ns: Namespace, sotaPackage: SotaCoreBlacklistedPackage): PackageListItem =
+    PackageListItem(ns, sotaPackage.packageId, sotaPackage.comment)
+
+  def getBlacklistedPackages(ns: Namespace): Future[Seq[PackageListItem]] = {
+    val path = uri.path / "api" / "v1" / "blacklist"
+    val req = HttpRequest(HttpMethods.GET, uri.withPath(path)).withNs(ns)
+    execHttp[Seq[SotaCoreBlacklistedPackage]](req)().map(_.map(sotaPakageToPackage(ns, _)))
+  }
+
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/common/Errors.scala
@@ -10,6 +10,7 @@ package com.advancedtelematic.ota.deviceregistry.common
 
 import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.{EntityAlreadyExists, MissingEntity, RawError}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.PackageListItem
 import com.advancedtelematic.ota.deviceregistry.data.{Group, GroupExpression}
 import com.advancedtelematic.ota.deviceregistry.data.GroupType.GroupType
 import com.advancedtelematic.ota.deviceregistry.db.GroupMemberRepository.GroupMember
@@ -64,4 +65,7 @@ object Errors {
              "cannot remove device from dynamic group")
 
   val MalformedInputFile = RawError(Codes.MalformedInput, StatusCodes.BadRequest, "The file cannot be read because it is malformed.")
+
+  val MissingPackageListItem = MissingEntity[PackageListItem]
+  val ConflictingPackageListItem = EntityAlreadyExists[PackageListItem]
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/Codecs.scala
@@ -1,8 +1,8 @@
 package com.advancedtelematic.ota.deviceregistry.data
 
 import io.circe.{Decoder, Encoder}
-import com.advancedtelematic.libats.codecs.CirceAnyVal.{anyValStringEncoder, anyValStringDecoder}
-import com.advancedtelematic.ota.deviceregistry.data.DataType.{DeviceT, InstallationStat, UpdateDevice}
+import com.advancedtelematic.libats.codecs.CirceAnyVal.{anyValStringDecoder, anyValStringEncoder}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{PackageListItem, PackageListItemCount, DeviceT, InstallationStat, UpdateDevice}
 
 object Codecs {
   private implicit val deviceIdEncoder = Encoder.encodeString.contramap[Device.DeviceOemId](_.underlying)
@@ -16,4 +16,8 @@ object Codecs {
 
   implicit val installationStatEncoder = io.circe.generic.semiauto.deriveEncoder[InstallationStat]
   implicit val installationStatDecoder = io.circe.generic.semiauto.deriveDecoder[InstallationStat]
+
+  implicit val packageListItemCodec = io.circe.generic.semiauto.deriveCodec[PackageListItem]
+
+  implicit val packageListItemCountCodec = io.circe.generic.semiauto.deriveCodec[PackageListItemCount]
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/data/DataType.scala
@@ -93,4 +93,7 @@ object DataType {
       require(notSeenSinceHours.isEmpty, "Invalid parameters: notSeenSinceHours must be empty when searching by deviceId.")
     }
   }
+
+  case class PackageListItem(namespace: Namespace, packageId: PackageId, comment: String)
+  case class PackageListItemCount(packageId: PackageId, deviceCount: Int)
 }

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstalledPackages.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/InstalledPackages.scala
@@ -62,7 +62,7 @@ object InstalledPackages {
     def * = (device, name, version, lastModified) <> (fromTuple, toTuple)
   }
 
-  private val installedPackages = TableQuery[InstalledPackageTable]
+  private[db] val installedPackages = TableQuery[InstalledPackageTable]
 
   def setInstalled(device: DeviceId, packages: Set[PackageId])(implicit ec: ExecutionContext): DBIO[Unit] =
     DBIO

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateBlacklistedPackages.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateBlacklistedPackages.scala
@@ -1,0 +1,36 @@
+package com.advancedtelematic.ota.deviceregistry.db
+
+import akka.Done
+import akka.stream.Materializer
+import akka.stream.scaladsl.Source
+import com.advancedtelematic.ota.deviceregistry.client.SotaCoreClient
+import com.advancedtelematic.ota.deviceregistry.data.DataType.PackageListItem
+import com.advancedtelematic.ota.deviceregistry.db.PackageListItemRepository.packageListItems
+import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository.devices
+import com.advancedtelematic.ota.deviceregistry.db.SlickMappings.namespaceColumnType
+import org.slf4j.LoggerFactory
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class MigrateBlacklistedPackages(sotaCoreClient: SotaCoreClient)
+                                (implicit db: Database, ec: ExecutionContext, mat: Materializer) {
+
+  private val _log = LoggerFactory.getLogger(this.getClass)
+
+  private def createOrUpdateBlacklistedPackage(packageListItem: PackageListItem) = {
+    _log.info(s"Inserting or updating blacklisted package: $packageListItem.")
+    packageListItems.insertOrUpdate(packageListItem)
+  }
+
+
+  def run: Future[Done] = {
+    val source = db.stream(devices.map(_.namespace).distinct.result)
+    Source
+      .fromPublisher(source)
+      .mapAsyncUnordered(1)(sotaCoreClient.getBlacklistedPackages)
+      .fold(Seq.empty[PackageListItem])(_ ++ _)
+      .map(_.map(createOrUpdateBlacklistedPackage))
+      .runForeach(_.map(db.run))
+  }
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/PackageListItemRepository.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/PackageListItemRepository.scala
@@ -1,0 +1,75 @@
+package com.advancedtelematic.ota.deviceregistry.db
+
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.slick.db.SlickExtensions._
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.ota.deviceregistry.common.Errors.{ConflictingPackageListItem, MissingPackageListItem}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{PackageListItem, PackageListItemCount}
+import com.advancedtelematic.ota.deviceregistry.data.PackageId
+import com.advancedtelematic.ota.deviceregistry.db.DeviceRepository.devices
+import com.advancedtelematic.ota.deviceregistry.db.InstalledPackages.installedPackages
+import com.advancedtelematic.ota.deviceregistry.db.SlickMappings._
+import slick.jdbc.MySQLProfile.api._
+
+import scala.concurrent.ExecutionContext
+
+object PackageListItemRepository {
+
+  /**
+    * Each record in the table represents one element of a list of packages.
+    * The list of packages are per namespace, i.e. if we group by namespace
+    * each group is a list of packages.
+    */
+  class PackageListItemTable(tag: Tag) extends Table[PackageListItem](tag, "PackageListItem") {
+    def namespace = column[Namespace]("namespace")
+    def packageName = column[PackageId.Name]("package_name")
+    def packageVersion = column[PackageId.Version]("package_version")
+    def comment = column[String]("comment")
+
+    def * = (namespace, packageName, packageVersion, comment) <>
+      (
+        { case (ns, pkgName, pkgVersion, comment) => PackageListItem(ns, PackageId(pkgName, pkgVersion), comment) },
+        { bp : PackageListItem => Some(bp.namespace, bp.packageId.name, bp.packageId.version, bp.comment) }
+      )
+
+    def pk = primaryKey("pk_PackageListItem", (namespace, packageName, packageVersion))
+  }
+
+  private[db] val packageListItems = TableQuery[PackageListItemTable]
+
+  private def findQuery(namespace: Namespace, packageId: PackageId) =
+    packageListItems
+      .filter(_.namespace === namespace)
+      .filter(_.packageName === packageId.name)
+      .filter(_.packageVersion === packageId.version)
+
+  def fetchPackageListItem(namespace: Namespace, packageId: PackageId)
+                          (implicit ec: ExecutionContext): DBIO[PackageListItem] =
+    findQuery(namespace, packageId).resultHead(MissingPackageListItem)
+
+  def fetchPackageListItemCounts(namespace: Namespace)
+                                (implicit ec: ExecutionContext): DBIO[Seq[PackageListItemCount]] =
+    devices
+      .filter(_.namespace === namespace)
+      .join(installedPackages)
+      .on(_.uuid === _.device)
+      .map(_._2)
+      .groupBy(ip => (ip.name, ip.version))
+      .map { case ((name, version), ips) => (name, version, ips.length) }
+      .join(packageListItems.filter(_.namespace === namespace))
+      .on { case ((name, version, _), bp) => bp.packageName === name && bp.packageVersion === version }
+      .map { case ((name, version, count), _) => LiftedPackageListItemCount(LiftedPackageId(name, version), count) }
+      .result
+
+  def create(packageListItem: PackageListItem)(implicit ec: ExecutionContext): DBIO[Int] =
+    (packageListItems += packageListItem).handleIntegrityErrors(ConflictingPackageListItem)
+
+  def update(packageListItem: PackageListItem)(implicit ec: ExecutionContext): DBIO[Int] =
+    findQuery(packageListItem.namespace, packageListItem.packageId)
+      .map(_.comment)
+      .update(packageListItem.comment)
+
+  def remove(namespace: Namespace, packageId: PackageId)(implicit ec: ExecutionContext): DBIO[Int] =
+    findQuery(namespace, packageId).delete
+
+}

--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/SlickMappings.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/SlickMappings.scala
@@ -10,7 +10,7 @@ package com.advancedtelematic.ota.deviceregistry.db
 
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.slick.codecs.SlickEnumMapper
-import com.advancedtelematic.ota.deviceregistry.data.DataType.IndexedEventType
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{PackageListItemCount, IndexedEventType}
 import com.advancedtelematic.ota.deviceregistry.data.{CredentialsType, GroupType, PackageId}
 import slick.jdbc.MySQLProfile.api._
 
@@ -28,4 +28,7 @@ object SlickMappings {
 
   private[db] implicit object LiftedPackageShape
     extends CaseClassShape(LiftedPackageId.tupled, (p: (PackageId.Name, PackageId.Version)) => PackageId(p._1, p._2))
+
+  private[db] case class LiftedPackageListItemCount(packageId: LiftedPackageId, deviceCount: Rep[Int])
+  private[db] implicit object ListedPackageListItemCountShape extends CaseClassShape(LiftedPackageListItemCount.tupled, PackageListItemCount.tupled)
 }

--- a/src/main/scala/db/migration/R__SotaCoreBlacklistedPackagesMigration.scala
+++ b/src/main/scala/db/migration/R__SotaCoreBlacklistedPackagesMigration.scala
@@ -1,0 +1,25 @@
+package db.migration
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.advancedtelematic.libats.http.ServiceHttpClientSupport
+import com.advancedtelematic.libats.slick.db.AppMigration
+import com.advancedtelematic.ota.deviceregistry.client.SotaCoreHttpClient
+import com.advancedtelematic.ota.deviceregistry.db.MigrateBlacklistedPackages
+import com.typesafe.config.ConfigFactory
+import slick.jdbc.MySQLProfile
+
+import scala.concurrent.Future
+
+class R__SotaCoreBlacklistedPackagesMigration extends AppMigration with ServiceHttpClientSupport {
+
+  implicit val system: ActorSystem = ActorSystem(this.getClass.getSimpleName)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  import system.dispatcher
+
+  private val sotaCoreUri = ConfigFactory.load().getString("sota_core.uri")
+  private val sotaCore = new SotaCoreHttpClient(sotaCoreUri, defaultHttpClient)
+
+  override def migrate(implicit db: MySQLProfile.api.Database): Future[Unit] =
+    new MigrateBlacklistedPackages(sotaCore).run.map(_ => ())
+}

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/PackageListsResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/PackageListsResourceSpec.scala
@@ -1,0 +1,149 @@
+package com.advancedtelematic.ota.deviceregistry
+
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.StatusCodes.{Created, NoContent, NotFound, OK}
+import cats.syntax.show._
+import com.advancedtelematic.libats.data.{ErrorCodes, ErrorRepresentation}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
+import com.advancedtelematic.ota.deviceregistry.Resource.uri
+import com.advancedtelematic.ota.deviceregistry.data.Codecs.{packageListItemCodec, packageListItemCountCodec}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{PackageListItem, PackageListItemCount, DeviceT}
+import com.advancedtelematic.ota.deviceregistry.data.GeneratorOps._
+import com.advancedtelematic.ota.deviceregistry.data.PackageId
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.ExecutionContext
+
+class PackageListsResourceSpec extends ResourcePropSpec with ScalaFutures {
+
+  private val genNonConflictingDeviceTs = Gen.choose(0, 20).flatMap(genConflictFreeDeviceTs)
+  private val genListedPackage: Gen[PackageListItem] =
+    for {
+      packageId <- genPackageId
+      comment   <- Gen.alphaNumStr
+    } yield PackageListItem(defaultNs, packageId, comment)
+
+  private implicit val arbListedPackage = Arbitrary(genListedPackage)
+  private implicit val arbNonConflictingDeviceTs = Arbitrary(genNonConflictingDeviceTs)
+
+  private def createListedPackage(listedPackage: PackageListItem): HttpRequest =
+    Post(uri("package_lists"), listedPackage)
+
+  private def createListedPackageOk(listedPackage: PackageListItem)(implicit ec: ExecutionContext): Unit =
+    createListedPackage(listedPackage) ~> route ~> check {
+      status shouldBe Created
+    }
+
+  private def getListedPackage(packageId: PackageId): HttpRequest =
+    Get(uri("package_lists", packageId.name, packageId.version))
+
+  private def getListedPackageOk(packageId: PackageId)(implicit ec: ExecutionContext): PackageListItem =
+    getListedPackage(packageId) ~> route ~> check {
+      status shouldBe OK
+      responseAs[PackageListItem]
+    }
+
+  private def deleteListedPackage(packageId: PackageId): HttpRequest =
+    Delete(uri("package_lists", packageId.name, packageId.version))
+
+  private def deleteListedPackageOk(packageId: PackageId)(implicit ec: ExecutionContext): Unit =
+    deleteListedPackage(packageId) ~> route ~> check {
+      status shouldBe NoContent
+    }
+
+  private def updateListedPackageOk(patchedListedPackage: PackageListItem): Unit =
+    Put(uri("package_lists"), patchedListedPackage) ~> route ~> check {
+      status shouldBe NoContent
+    }
+
+  private def updateInstalledPackages(deviceId: DeviceId, packageIds: Seq[PackageId]): Unit =
+    Put(uri("mydevice", deviceId.show, "packages"), packageIds) ~> route ~> check {
+      status shouldBe NoContent
+    }
+
+  property("can create a listed package") {
+    forAll { listedPackage: PackageListItem =>
+      createListedPackageOk(listedPackage)
+    }
+  }
+
+  property("can get a listed package") {
+    forAll { listedPackage: PackageListItem =>
+      createListedPackageOk(listedPackage)
+      val actual = getListedPackageOk(listedPackage.packageId)
+      actual shouldBe listedPackage
+    }
+  }
+
+  property("fails to get a non-existing listed package") {
+    forAll { listedPackage: PackageListItem =>
+      getListedPackage(listedPackage.packageId) ~> route ~> check {
+        status shouldBe NotFound
+        responseAs[ErrorRepresentation].code shouldBe ErrorCodes.MissingEntity
+      }
+    }
+  }
+
+  property("can delete a listed package") {
+    forAll { listedPackage: PackageListItem =>
+      createListedPackageOk(listedPackage)
+      deleteListedPackageOk(listedPackage.packageId)
+    }
+  }
+
+  property("deleting a non-existing listed package succeeds") {
+    forAll { listedPackage: PackageListItem =>
+      deleteListedPackageOk(listedPackage.packageId)
+    }
+  }
+
+  property("can update the comment of a listed package") {
+    forAll { (listedPackage: PackageListItem, newComment: String) =>
+      createListedPackageOk(listedPackage)
+      val patchedListedPackage = listedPackage.copy(comment = newComment)
+      updateListedPackageOk(patchedListedPackage)
+      getListedPackageOk(listedPackage.packageId) shouldBe patchedListedPackage
+    }
+  }
+
+  property("updating the comment of a listed package succeeds") {
+    forAll { (listedPackage: PackageListItem, newComment: String) =>
+      val patchedListedPackage = listedPackage.copy(comment = newComment)
+      updateListedPackageOk(patchedListedPackage)
+      getListedPackage(listedPackage.packageId) ~> route ~> check {
+        status shouldBe NotFound
+      }
+    }
+  }
+
+  property("can count how many devices have installed each of the listed packages") {
+    forAll(SizeRange(20)) { (deviceTs: Seq[DeviceT], packageIds: Seq[PackageId], comment: String) =>
+
+      val listedPackages = Gen.someOf(packageIds).generate.map(PackageListItem(defaultNs, _, comment))
+      val deviceIds = deviceTs.map(createDeviceOk)
+      val devicesWithPackages = deviceIds.map(did => did -> Gen.someOf(packageIds).generate)
+
+      val expected = devicesWithPackages
+        .flatMap { case (did, pids) => pids.map(pid => pid -> did) }
+        .groupBy(_._1)
+        .filterKeys(listedPackages.map(_.packageId).contains)
+        .mapValues(_.map(_._2).length)
+        .map((PackageListItemCount.apply _).tupled)
+        .toSeq
+
+      listedPackages.foreach(createListedPackageOk)
+      devicesWithPackages.foreach((updateInstalledPackages _).tupled)
+
+      val actual = Get(uri("package_lists")) ~> route ~> check {
+        status shouldBe OK
+        responseAs[Seq[PackageListItemCount]]
+      }
+
+      val actualInThisRun = actual.filter(bp => packageIds.contains(bp.packageId))
+      actualInThisRun should contain theSameElementsAs expected
+    }
+  }
+
+}

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateBlacklistedPackagesSpec.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateBlacklistedPackagesSpec.scala
@@ -1,0 +1,67 @@
+package com.advancedtelematic.ota.deviceregistry.db
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.RawHeader
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.libats.test.DatabaseSpec
+import com.advancedtelematic.ota.deviceregistry.client.SotaCoreBlacklistedPackage
+import com.advancedtelematic.ota.deviceregistry.data.Codecs.deviceTEncoder
+import com.advancedtelematic.ota.deviceregistry.data.DataType.{PackageListItem, DeviceT}
+import com.advancedtelematic.ota.deviceregistry.util.FakeSotaCoreClient
+import com.advancedtelematic.ota.deviceregistry.{Resource, ResourcePropSpec}
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.Matchers
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.SpanSugar._
+import slick.jdbc.MySQLProfile.api._
+
+class MigrateBlacklistedPackagesSpec extends ResourcePropSpec
+  with DatabaseSpec
+  with ScalaFutures
+  with Matchers
+  with Eventually {
+
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, 50.millis)
+
+  private val genSotaCoreBlacklistedPackage: Gen[SotaCoreBlacklistedPackage] =
+    for {
+      packageId <- genPackageId
+      comment   <- Gen.alphaNumStr
+    } yield SotaCoreBlacklistedPackage(packageId, comment)
+
+  private implicit val arbSotaCoreBlacklistedPackage = Arbitrary(genSotaCoreBlacklistedPackage)
+  private implicit val arbNamespace = Arbitrary(Gen.const(Namespace.generate))
+
+  private def createDevice(ns: Namespace, deviceT: DeviceT): Unit =
+    Post(Resource.uri(api), deviceT).withHeaders(RawHeader("x-ats-namespace", ns.get)) ~> route ~> check {
+      status shouldBe StatusCodes.Created
+      ()
+    }
+
+  property("should store blacklisted packages from sota-core") {
+    forAll(SizeRange(5)) { blacklist: Map[Namespace, (DeviceT, Seq[SotaCoreBlacklistedPackage])] =>
+      val sotaCoreClient = new FakeSotaCoreClient
+      val migrator = new MigrateBlacklistedPackages(sotaCoreClient)
+      val expected = blacklist.flatMap { case (ns, (_, bps)) =>
+        bps.map(bp => PackageListItem(ns, bp.packageId, bp.comment))
+      }
+
+      blacklist.foreach { case (ns, (d, _)) => createDevice(ns, d) }
+      blacklist.foreach { case (ns, (_, bps)) => sotaCoreClient.addBlacklistedPackages(ns, bps) }
+
+      migrator.run.futureValue
+
+      eventually {
+        val action = DBIO.sequence {
+          blacklist.flatMap { case (ns, (_, bps)) =>
+            bps.map(bp => PackageListItemRepository.fetchPackageListItem(ns, bp.packageId))
+          }
+        }
+        val actual = db.run(action).futureValue
+        actual should contain theSameElementsAs expected
+      }
+    }
+  }
+
+}

--- a/src/test/scala/com/advancedtelematic/ota/deviceregistry/util/FakeSotaCoreClient.scala
+++ b/src/test/scala/com/advancedtelematic/ota/deviceregistry/util/FakeSotaCoreClient.scala
@@ -1,0 +1,25 @@
+package com.advancedtelematic.ota.deviceregistry.util
+
+import java.util.concurrent.ConcurrentHashMap
+
+import akka.http.scaladsl.util.FastFuture
+import com.advancedtelematic.libats.data.DataType.Namespace
+import com.advancedtelematic.ota.deviceregistry.client.{SotaCoreBlacklistedPackage, SotaCoreClient}
+import com.advancedtelematic.ota.deviceregistry.data.DataType.PackageListItem
+
+import scala.concurrent.Future
+
+class FakeSotaCoreClient extends SotaCoreClient {
+
+  private val blacklistedPackages = new ConcurrentHashMap[Namespace, Seq[SotaCoreBlacklistedPackage]]()
+
+  def addBlacklistedPackages(ns: Namespace, newBlacklistedPackages: Seq[SotaCoreBlacklistedPackage]): Unit =
+    blacklistedPackages.put(ns, newBlacklistedPackages)
+
+  override def getBlacklistedPackages(ns: Namespace): Future[Seq[PackageListItem]] =
+    FastFuture.successful {
+      blacklistedPackages
+        .getOrDefault(ns, Seq.empty)
+        .map(sp => PackageListItem(ns, sp.packageId, sp.comment))
+    }
+}


### PR DESCRIPTION
The now-deprecated ota-core service serves a "blacklisting" feature. The quotes are because it's not actually blacklisting anything. It is used to count the number of devices that have a particular package installed. This are the installed packages reported by aktualizr, e.g. 'nano' for a linux distribution, not to be confused with the images we can install through our system.

We move that functionality here to discontinue the ota-core service.

The actual migration is in a stand-alone commit that can (and probably should) be reverted once the blacklist has been migrated in all the environments.