### PR TITLE
Fix sota-core blacklist migration (reprise!).

### DIFF
--- a/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateBlacklistedPackages.scala
+++ b/src/main/scala/com/advancedtelematic/ota/deviceregistry/db/MigrateBlacklistedPackages.scala
@@ -28,9 +28,9 @@ class MigrateBlacklistedPackages(sotaCoreClient: SotaCoreClient)
     val source = db.stream(devices.map(_.namespace).distinct.result)
     Source
       .fromPublisher(source)
-      .mapAsyncUnordered(1)(sotaCoreClient.getBlacklistedPackages)
-      .fold(Seq.empty[PackageListItem])(_ ++ _)
+      .mapAsyncUnordered(3)(sotaCoreClient.getBlacklistedPackages)
       .map(_.map(createOrUpdateBlacklistedPackage))
-      .runForeach(action => db.run(DBIO.sequence(action)))
+      .mapAsyncUnordered(3)(a => db.run(DBIO.sequence(a)))
+      .runForeach(s => _log.info(s"Migrated ${s.length} records."))
   }
 }


### PR DESCRIPTION
The symptoms of the failing migration was that it was migrating the
first ~30 records, and then finishing successfully (!).

The issue was that `runForeach` takes a function that returns a `Unit`,
but I was giving it a function that returns a `Future`. The `Future`
was casted to a `Unit` and the migration didn't wait for the `Future`
to complete, instead finishing once the stream source was over.

To fix it, one should use `mapAsyncUnordered` or `foldAsync` when the
function we pass returns a `Future` and we need to wait for it.