### PR TITLE
Change of id parameter to deviceUuid

### DIFF
--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -172,7 +172,7 @@ components:
       - uuid
       - deviceId
       properties:
-        id:
+        deviceUuid:
           type: string
           format: uuid
         deviceId:
@@ -274,14 +274,14 @@ components:
 
     Device:
       type: object
-      required: [uuid, deviceId, name, status]
+      required: [deviceId, uuid, name, status]
       properties:
-        id:
-          type: string
-          format: uuid
         deviceId:
           type: string
           format: string
+        deviceUuid:
+          type: string
+          format: uuid
         name:
           type: string
           format: string

--- a/src/main/resources/api-definition.yml
+++ b/src/main/resources/api-definition.yml
@@ -274,7 +274,7 @@ components:
 
     Device:
       type: object
-      required: [deviceId, uuid, name, status]
+      required: [deviceId, deviceUuid, name, status]
       properties:
         deviceId:
           type: string


### PR DESCRIPTION
Within the schemas "Device" and "SimplifiedDevice", I changed the name `id` to `deviceUuid` in order to maintain consistency with the other schema descriptions of the `uuid`.

Signed-off-by: amma <awuraaamma.okyere-boateng@here.com>